### PR TITLE
feat: 관리자 물품 삭제 API 구현 완료

### DIFF
--- a/src/main/kotlin/site/billilge/api/backend/domain/admin/controller/AdminApi.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/admin/controller/AdminApi.kt
@@ -71,4 +71,25 @@ interface AdminApi {
         @RequestPart image: MultipartFile?,
         @RequestPart itemRequest: ItemRequest
     ): ResponseEntity<Void>
+
+    @Operation(
+        summary = "대여 물품 삭제",
+        description = "대여 물품을 삭제하는 관리자용 API"
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "204",
+                description = "대여 물품 삭제 성공"
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "물품 정보가 존재하지 않습니다.",
+                content = [Content(schema = Schema(implementation = ErrorResponse::class))]
+            )
+        ]
+    )
+    fun deleteItem(
+        @PathVariable itemId: Long,
+    ): ResponseEntity<Void>
 }

--- a/src/main/kotlin/site/billilge/api/backend/domain/admin/controller/AdminController.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/admin/controller/AdminController.kt
@@ -40,4 +40,10 @@ class AdminController(
         adminService.updateItem(image, itemId, itemRequest)
         return ResponseEntity.ok().build()
     }
+
+    @DeleteMapping("/items/{itemId}")
+    override fun deleteItem(@PathVariable itemId: Long): ResponseEntity<Void> {
+        adminService.deleteItem(itemId)
+        return ResponseEntity.noContent().build()
+    }
 }

--- a/src/main/kotlin/site/billilge/api/backend/global/exception/GlobalErrorCode.kt
+++ b/src/main/kotlin/site/billilge/api/backend/global/exception/GlobalErrorCode.kt
@@ -10,4 +10,6 @@ enum class GlobalErrorCode(
     INVALID_AUTHORIZATION_HEADER("유효하지 않은 Authorization 헤더입니다.", HttpStatus.BAD_REQUEST),
     FORBIDDEN("접근 권한이 없습니다.", HttpStatus.FORBIDDEN),
     IMAGE_UPLOAD_FAILED("이미지 업로드에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    IMAGE_NOT_FOUND("이미지 파일을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    IMAGE_DELETE_FAILED("이미지 삭제에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#4 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

물품 API에 누락되어 있던 관리자 대여 물품 삭제 API를 구현하였습니다.

- 대여 물품 삭제 (/admin/items/{itemId}) [DELETE]

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
