### PR TITLE
feat: 회원 역할 변경 및 관리자 목록 API 구현 완료

### DIFF
--- a/src/main/kotlin/site/billilge/api/backend/domain/admin/controller/AdminApi.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/admin/controller/AdminApi.kt
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.multipart.MultipartFile
+import site.billilge.api.backend.domain.admin.dto.response.AdminFindAllResponse
 import site.billilge.api.backend.domain.item.dto.request.ItemRequest
 import site.billilge.api.backend.domain.item.dto.response.ItemFindAllResponse
 import site.billilge.api.backend.global.exception.ErrorResponse
@@ -92,4 +93,37 @@ interface AdminApi {
     fun deleteItem(
         @PathVariable itemId: Long,
     ): ResponseEntity<Void>
+
+    @Operation(
+        summary = "관리자 목록 조회",
+        description = "관리자 목록을 조회하는 API"
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "관리자 목록 조회 성공"
+            )
+        ]
+    )
+    fun getAdminList(): ResponseEntity<AdminFindAllResponse>
+
+    @Operation(
+        summary = "회원 권한 변경",
+        description = "회원의 권한(사용자/관리자)을 변경하는 관리자용 API"
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "회원이 사용자라면 관리자로, 관리자라면 사용자로 권한 변경 성공"
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "회원을 찾을 수 없습니다.",
+                content = [Content(schema = Schema(implementation = ErrorResponse::class))]
+            )
+        ]
+    )
+    fun updateMemberRole(@PathVariable memberId: Long): ResponseEntity<Void>
 }

--- a/src/main/kotlin/site/billilge/api/backend/domain/admin/controller/AdminController.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/admin/controller/AdminController.kt
@@ -5,6 +5,7 @@ import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.multipart.MultipartFile
+import site.billilge.api.backend.domain.admin.dto.response.AdminFindAllResponse
 import site.billilge.api.backend.domain.admin.service.AdminService
 import site.billilge.api.backend.domain.item.dto.request.ItemRequest
 import site.billilge.api.backend.domain.item.dto.response.ItemFindAllResponse
@@ -45,5 +46,16 @@ class AdminController(
     override fun deleteItem(@PathVariable itemId: Long): ResponseEntity<Void> {
         adminService.deleteItem(itemId)
         return ResponseEntity.noContent().build()
+    }
+
+    @GetMapping("/members/admins")
+    override fun getAdminList(): ResponseEntity<AdminFindAllResponse> {
+        return ResponseEntity.ok(adminService.getAdminList())
+    }
+
+    @PatchMapping("/members/roles/{memberId}")
+    override fun updateMemberRole(@PathVariable memberId: Long): ResponseEntity<Void> {
+        adminService.updateMemberRole(memberId)
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/kotlin/site/billilge/api/backend/domain/admin/dto/response/AdminFindAllResponse.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/admin/dto/response/AdminFindAllResponse.kt
@@ -1,0 +1,5 @@
+package site.billilge.api.backend.domain.admin.dto.response
+
+data class AdminFindAllResponse(
+    val admins: List<AdminMemberDetail>
+)

--- a/src/main/kotlin/site/billilge/api/backend/domain/admin/dto/response/AdminMemberDetail.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/admin/dto/response/AdminMemberDetail.kt
@@ -1,0 +1,20 @@
+package site.billilge.api.backend.domain.admin.dto.response
+
+import site.billilge.api.backend.domain.member.entity.Member
+
+data class AdminMemberDetail(
+    val memberId: Long,
+    val name: String,
+    val studentId: Int
+) {
+    companion object {
+        @JvmStatic
+        fun from(member: Member): AdminMemberDetail {
+            return AdminMemberDetail(
+                memberId = member.id!!,
+                name = member.name,
+                studentId = member.studentId
+            )
+        }
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#5 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

회원 역할 변경 및 관리자 목록 API 구현 완료했습니다.

회원 역할 변경 API는 대상 회원이 관리자일 때는 사용자로, 사용자일 때는 관리자로 역할을 변경합니다. 

- 회원 역할 변경 (/admin/members/roles/{memberId}) [PATCH]
- 관리자 목록 조회 (/admin/members/admins) [GET]

### 스크린샷 (선택)

<img width="1276" alt="스크린샷 2025-01-15 오후 4 54 59" src="https://github.com/user-attachments/assets/4d172e82-1a81-4f77-987e-65092943da62" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
