### PR TITLE
fix: 학생회비 납부자 삭제 시 회원의 학생회비 납부 여부가 업데이트되지 않던 현상 수정 완료

### DIFF
--- a/src/main/kotlin/site/billilge/api/backend/domain/member/repository/MemberRepository.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/member/repository/MemberRepository.kt
@@ -22,6 +22,6 @@ interface MemberRepository: JpaRepository<Member, Long> {
     @Query("select m from Member m where m.id in :ids")
     fun findAllByIds(@Param("ids") ids: List<Long>): List<Member>
 
-    @Query("select m from Member m where m.studentId in :ids")
+    @Query("select m from Member m where m.studentId in :studentIds")
     fun findAllByStudentIds(@Param("studentIds") studentIds: List<String>): List<Member>
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#21 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 학생회비 납부자 삭제 시 회원의 학생회비 납부 여부가 업데이트되지 않던 현상을 수정하였습니다.
  - 학번 목록으로 회원들을 조회하는 쿼리문을 수정했습니다.

### 스크린샷 (선택)

![image](https://github.com/user-attachments/assets/4c1fc33b-70f6-4a89-b9e2-0b8c9b495df1)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
