### PR TITLE
refactor: svg 확장자 이미지만 업로드 가능하도록 수정 및 ItemRequest 수정사항 반영 완료

### DIFF
--- a/src/main/kotlin/site/billilge/api/backend/domain/item/dto/request/ItemRequest.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/item/dto/request/ItemRequest.kt
@@ -1,7 +1,9 @@
 package site.billilge.api.backend.domain.item.dto.request
 
+import site.billilge.api.backend.domain.item.enums.ItemType
+
 data class ItemRequest(
     val name: String,
-    val isConsumption: Boolean,
+    val type: ItemType,
     val count: Int,
 )

--- a/src/main/kotlin/site/billilge/api/backend/domain/item/exception/ItemErrorCode.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/item/exception/ItemErrorCode.kt
@@ -10,4 +10,5 @@ enum class ItemErrorCode(
     ITEM_ID_IS_NULL("물품의 ID를 가져올 수 없습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     ITEM_NAME_ALREADY_EXISTS("이미 존재하는 물품 이름입니다.", HttpStatus.BAD_REQUEST),
     ITEM_NOT_FOUND("물품 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    IMAGE_IS_NOT_SVG("이미지 파일은 svg 확장자만 가능합니다.", HttpStatus.BAD_REQUEST),
 }

--- a/src/main/kotlin/site/billilge/api/backend/global/external/s3/S3Service.kt
+++ b/src/main/kotlin/site/billilge/api/backend/global/external/s3/S3Service.kt
@@ -26,7 +26,7 @@ class S3Service(
         val changedName = newFileName + ext
 
         val metadata = ObjectMetadata().apply {
-            contentType = "image/$ext"
+            contentType = imageFile.contentType
             contentLength = imageFile.size
         }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#19 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- checkImageIsSvg() 함수를 통해 요청에서 받아온 MultipartFile이 svg 타입인지 확인하도록 했습니다.
- ItemRequest에서 isConsumption이 아닌 type으로 물품 타입을 받아오도록 수정하였습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

테스트 안 해봄... 이따 해볼게요 ㅎㅎ