### PR TITLE
feat: 회원 목록 조회 API 구현

### DIFF
--- a/src/main/kotlin/site/billilge/api/backend/domain/member/controller/AdminMemberApi.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/member/controller/AdminMemberApi.kt
@@ -6,11 +6,32 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.ModelAttribute
+import org.springframework.web.bind.annotation.RequestBody
+import site.billilge.api.backend.domain.member.dto.request.AdminRequest
 import site.billilge.api.backend.domain.member.dto.response.AdminFindAllResponse
+import site.billilge.api.backend.domain.member.dto.response.MemberFindAllResponse
 import site.billilge.api.backend.global.dto.PageableCondition
+import site.billilge.api.backend.global.dto.SearchCondition
 
 @Tag(name = "(Admin) Member", description = "관리자용 관리자 API")
 interface AdminMemberApi {
+    @Operation(
+        summary = "회원 목록 조회",
+        description = "회원 목록을 조회하는 API"
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "회원 목록 조회 성공"
+            )
+        ]
+    )
+    fun getAllMembers(
+        @ModelAttribute pageableCondition: PageableCondition,
+        @ModelAttribute searchCondition: SearchCondition
+    ): ResponseEntity<MemberFindAllResponse>
+
     @Operation(
         summary = "관리자 목록 조회",
         description = "관리자 목록을 조회하는 API"
@@ -28,4 +49,32 @@ interface AdminMemberApi {
 //        @RequestParam(required = false, defaultValue = "0") pageNo: Int,
 //        @RequestParam(required = false, defaultValue = "10") size: Int
     ): ResponseEntity<AdminFindAllResponse>
+
+    @Operation(
+        summary = "관리자 추가",
+        description = "회원을 관리자에 추가하는 API"
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "관리자 추가 성공"
+            )
+        ]
+    )
+    fun addAdmins(@RequestBody request: AdminRequest): ResponseEntity<Void>
+
+    @Operation(
+        summary = "관리자 삭제",
+        description = "관리자 목록에서 회원을 삭제하는 API"
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "204",
+                description = "관리자 삭제 성공"
+            )
+        ]
+    )
+    fun deleteAdmins(@RequestBody request: AdminRequest): ResponseEntity<Void>
 }

--- a/src/main/kotlin/site/billilge/api/backend/domain/member/controller/AdminMemberController.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/member/controller/AdminMemberController.kt
@@ -4,9 +4,11 @@ import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import site.billilge.api.backend.domain.member.dto.request.AdminRequest
 import site.billilge.api.backend.domain.member.dto.response.AdminFindAllResponse
+import site.billilge.api.backend.domain.member.dto.response.MemberFindAllResponse
 import site.billilge.api.backend.domain.member.service.MemberService
 import site.billilge.api.backend.global.annotation.OnlyAdmin
 import site.billilge.api.backend.global.dto.PageableCondition
+import site.billilge.api.backend.global.dto.SearchCondition
 
 @RestController
 @RequestMapping("admin/members")
@@ -14,6 +16,15 @@ import site.billilge.api.backend.global.dto.PageableCondition
 class AdminMemberController(
     private val memberService: MemberService
 ) : AdminMemberApi {
+
+    @GetMapping
+    override fun getAllMembers(
+        @ModelAttribute pageableCondition: PageableCondition,
+        @ModelAttribute searchCondition: SearchCondition
+    ): ResponseEntity<MemberFindAllResponse> {
+        return ResponseEntity.ok(memberService.getAllMembers(pageableCondition, searchCondition))
+    }
+
     @GetMapping("/admins")
     override fun getAdminList(
         @ModelAttribute pageableCondition: PageableCondition
@@ -22,13 +33,13 @@ class AdminMemberController(
     }
 
     @PostMapping("/admins")
-    fun addAdmins(@RequestBody request: AdminRequest): ResponseEntity<Void> {
+    override fun addAdmins(@RequestBody request: AdminRequest): ResponseEntity<Void> {
         memberService.addAdmins(request)
         return ResponseEntity.ok().build()
     }
 
     @DeleteMapping("/admins")
-    fun deleteAdmins(@RequestBody request: AdminRequest): ResponseEntity<Void> {
+    override fun deleteAdmins(@RequestBody request: AdminRequest): ResponseEntity<Void> {
         memberService.deleteAdmins(request)
         return ResponseEntity.noContent().build()
     }

--- a/src/main/kotlin/site/billilge/api/backend/domain/member/dto/response/MemberDetail.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/member/dto/response/MemberDetail.kt
@@ -1,0 +1,25 @@
+package site.billilge.api.backend.domain.member.dto.response
+
+import site.billilge.api.backend.domain.member.entity.Member
+import site.billilge.api.backend.domain.member.enums.Role
+
+data class MemberDetail(
+    val memberId: Long,
+    val name: String,
+    val studentId: String,
+    val isFeePaid: Boolean,
+    val role: Role
+) {
+    companion object {
+        @JvmStatic
+        fun from(member: Member): MemberDetail {
+            return MemberDetail(
+                memberId = member.id!!,
+                name = member.name,
+                studentId = member.studentId,
+                isFeePaid = member.isFeePaid,
+                role = member.role
+            )
+        }
+    }
+}

--- a/src/main/kotlin/site/billilge/api/backend/domain/member/dto/response/MemberFindAllResponse.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/member/dto/response/MemberFindAllResponse.kt
@@ -1,0 +1,8 @@
+package site.billilge.api.backend.domain.member.dto.response
+
+import site.billilge.api.backend.global.dto.PageableResponse
+
+data class MemberFindAllResponse(
+    val members: List<MemberDetail>,
+    override val totalPage: Int
+): PageableResponse

--- a/src/main/kotlin/site/billilge/api/backend/domain/member/repository/MemberRepository.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/member/repository/MemberRepository.kt
@@ -19,6 +19,9 @@ interface MemberRepository: JpaRepository<Member, Long> {
 
     fun findAllByRole(role: Role, pageable: Pageable): Page<Member>
 
+    @Query("SELECT m FROM Member m WHERE m.name LIKE CONCAT('%', :name, '%')")
+    fun findAllByNameContaining(@Param("name") name: String, pageable: Pageable): Page<Member>
+
     @Query("select m from Member m where m.id in :ids")
     fun findAllByIds(@Param("ids") ids: List<Long>): List<Member>
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#23 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 회원 목록 조회 (/admin/members) [GET]
  - 쿼리 파라미터
    - pageNo: 페이지 번호
    - size: 페이지당 개수
    - search: 검색어

### 스크린샷 (선택)

<img width="1283" alt="image" src="https://github.com/user-attachments/assets/7a1e23e4-fe4f-408a-9fcd-a8cc4fffec97" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
