### PR TITLE
feat: 관리자용 물품 목록 조회 API 구현

### DIFF
--- a/src/main/kotlin/site/billilge/api/backend/domain/item/controller/AdminItemApi.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/item/controller/AdminItemApi.kt
@@ -7,11 +7,15 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ModelAttribute
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestPart
 import org.springframework.web.multipart.MultipartFile
 import site.billilge.api.backend.domain.item.dto.request.ItemRequest
+import site.billilge.api.backend.domain.item.dto.response.AdminItemFindAllResponse
 import site.billilge.api.backend.domain.item.dto.response.ItemFindAllResponse
+import site.billilge.api.backend.global.dto.PageableCondition
+import site.billilge.api.backend.global.dto.SearchCondition
 import site.billilge.api.backend.global.exception.ErrorResponse
 
 @Tag(name = "(Admin) Item", description = "관리자용 물품 API")
@@ -28,7 +32,10 @@ interface AdminItemApi {
             )
         ]
     )
-    fun getAllItems(): ResponseEntity<ItemFindAllResponse>
+    fun getAllAdminItems(
+        @ModelAttribute pageableCondition: PageableCondition,
+        @ModelAttribute searchCondition: SearchCondition
+    ): ResponseEntity<AdminItemFindAllResponse>
 
     @Operation(
         summary = "대여 물품 등록",

--- a/src/main/kotlin/site/billilge/api/backend/domain/item/controller/AdminItemController.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/item/controller/AdminItemController.kt
@@ -6,9 +6,11 @@ import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.multipart.MultipartFile
 import site.billilge.api.backend.domain.item.dto.request.ItemRequest
-import site.billilge.api.backend.domain.item.dto.response.ItemFindAllResponse
+import site.billilge.api.backend.domain.item.dto.response.AdminItemFindAllResponse
 import site.billilge.api.backend.domain.item.service.ItemService
 import site.billilge.api.backend.global.annotation.OnlyAdmin
+import site.billilge.api.backend.global.dto.PageableCondition
+import site.billilge.api.backend.global.dto.SearchCondition
 
 @RestController
 @RequestMapping("/admin/items")
@@ -17,8 +19,16 @@ class AdminItemController(
     private val itemService: ItemService
 ) : AdminItemApi {
     @GetMapping
-    override fun getAllItems(): ResponseEntity<ItemFindAllResponse> {
-        return ResponseEntity.ok(itemService.getAllItems())
+    override fun getAllAdminItems(
+        @ModelAttribute pageableCondition: PageableCondition,
+        @ModelAttribute searchCondition: SearchCondition
+    ): ResponseEntity<AdminItemFindAllResponse> {
+        return ResponseEntity.ok(
+            itemService.getAllAdminItems(
+                pageableCondition,
+                searchCondition
+            )
+        )
     }
 
     @PostMapping(consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])

--- a/src/main/kotlin/site/billilge/api/backend/domain/item/dto/response/AdminItemDetail.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/item/dto/response/AdminItemDetail.kt
@@ -1,0 +1,12 @@
+package site.billilge.api.backend.domain.item.dto.response
+
+import site.billilge.api.backend.domain.item.enums.ItemType
+
+data class AdminItemDetail(
+    val itemId: Long,
+    val itemName: String,
+    val itemType: ItemType,
+    val count: Int,
+    val renterCount: Long,
+    val imageUrl: String
+)

--- a/src/main/kotlin/site/billilge/api/backend/domain/item/dto/response/AdminItemFindAllResponse.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/item/dto/response/AdminItemFindAllResponse.kt
@@ -1,0 +1,8 @@
+package site.billilge.api.backend.domain.item.dto.response
+
+import site.billilge.api.backend.global.dto.PageableResponse
+
+data class AdminItemFindAllResponse(
+    val items: List<AdminItemDetail>,
+    override val totalPage: Int
+): PageableResponse

--- a/src/main/kotlin/site/billilge/api/backend/domain/item/repository/ItemRepository.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/item/repository/ItemRepository.kt
@@ -4,7 +4,7 @@ import org.springframework.data.jpa.repository.JpaRepository
 import site.billilge.api.backend.domain.item.entity.Item
 import java.util.*
 
-interface ItemRepository: JpaRepository<Item, Long> {
+interface ItemRepository: JpaRepository<Item, Long>, ItemRepositoryCustom {
     override fun findById(id: Long): Optional<Item>
     fun existsByName(name: String): Boolean
 }

--- a/src/main/kotlin/site/billilge/api/backend/domain/item/repository/ItemRepositoryCustom.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/item/repository/ItemRepositoryCustom.kt
@@ -1,0 +1,9 @@
+package site.billilge.api.backend.domain.item.repository
+
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import site.billilge.api.backend.domain.item.dto.response.AdminItemDetail
+
+interface ItemRepositoryCustom {
+    fun findAllAsAdminItemDetailByKeyword(keyword: String, pageable: Pageable): Page<AdminItemDetail>
+}

--- a/src/main/kotlin/site/billilge/api/backend/domain/item/repository/ItemRepositoryCustomImpl.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/item/repository/ItemRepositoryCustomImpl.kt
@@ -1,0 +1,45 @@
+package site.billilge.api.backend.domain.item.repository
+
+import com.querydsl.core.types.ExpressionUtils
+import com.querydsl.core.types.Projections
+import com.querydsl.jpa.JPAExpressions
+import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.support.PageableExecutionUtils
+import site.billilge.api.backend.domain.item.dto.response.AdminItemDetail
+import site.billilge.api.backend.domain.item.entity.QItem
+import site.billilge.api.backend.domain.rental.entity.QRentalHistory
+
+class ItemRepositoryCustomImpl(
+    private val queryFactory: JPAQueryFactory
+) : ItemRepositoryCustom {
+    override fun findAllAsAdminItemDetailByKeyword(keyword: String, pageable: Pageable): Page<AdminItemDetail> {
+        val item = QItem.item
+        val rentalHistory = QRentalHistory.rentalHistory
+
+        val contents = queryFactory
+            .select(
+                Projections.constructor(
+                    AdminItemDetail::class.java,
+                    item.id.`as`("itemId"),
+                    item.name.`as`("itemName"),
+                    item.type.`as`("itemType"),
+                    item.count,
+                    ExpressionUtils.`as`(
+                        JPAExpressions
+                            .select(rentalHistory.count())
+                            .from(rentalHistory)
+                            .where(rentalHistory.item.eq(item)),
+                        "renterCount"
+                    ),
+                    item.imageUrl
+                )
+            )
+            .from(item)
+            .where(item.name.like("%$keyword%"))
+            .fetch()
+
+        return PageableExecutionUtils.getPage(contents, pageable) { contents.size.toLong() }
+    }
+}

--- a/src/main/kotlin/site/billilge/api/backend/domain/item/service/ItemService.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/item/service/ItemService.kt
@@ -1,14 +1,20 @@
 package site.billilge.api.backend.domain.item.service
 
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.bind.annotation.ModelAttribute
 import org.springframework.web.multipart.MultipartFile
 import site.billilge.api.backend.domain.item.dto.request.ItemRequest
+import site.billilge.api.backend.domain.item.dto.response.AdminItemFindAllResponse
 import site.billilge.api.backend.domain.item.dto.response.ItemDetail
 import site.billilge.api.backend.domain.item.dto.response.ItemFindAllResponse
 import site.billilge.api.backend.domain.item.entity.Item
 import site.billilge.api.backend.domain.item.exception.ItemErrorCode
 import site.billilge.api.backend.domain.item.repository.ItemRepository
+import site.billilge.api.backend.global.dto.PageableCondition
+import site.billilge.api.backend.global.dto.SearchCondition
 import site.billilge.api.backend.global.exception.ApiException
 import site.billilge.api.backend.global.exception.GlobalErrorCode
 import site.billilge.api.backend.global.external.s3.S3Service
@@ -21,9 +27,23 @@ class ItemService(
 ) {
     fun getAllItems(): ItemFindAllResponse {
         val itemDetails = itemRepository.findAll()
-            .map { item -> ItemDetail.from(item) }
+            .map { ItemDetail.from(it) }
 
         return ItemFindAllResponse(itemDetails)
+    }
+
+    fun getAllAdminItems(
+        @ModelAttribute pageableCondition: PageableCondition,
+        @ModelAttribute searchCondition: SearchCondition,
+    ): AdminItemFindAllResponse {
+        val pageRequest = PageRequest.of(
+            pageableCondition.pageNo,
+            pageableCondition.size,
+            Sort.by(Sort.Direction.ASC, "name")
+        )
+        val adminItemDetails = itemRepository.findAllAsAdminItemDetailByKeyword(searchCondition.search, pageRequest)
+
+        return AdminItemFindAllResponse(adminItemDetails.content, adminItemDetails.totalPages)
     }
 
     @Transactional


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#26 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 관리자용 물품 목록 조회 (/admin/items) [GET]
  - 쿼리 파라미터
    - pageNo: 페이지 번호
    - size: 페이지당 개수
    - search: 검색어

- QueryDSL을 활용하여 물품 목록 조회 쿼리를 1개로 구현하였습니다.

### 스크린샷 (선택)

<img width="1282" alt="image" src="https://github.com/user-attachments/assets/63baa154-530f-4698-8eb7-7612f8f9f445" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
