### PR TITLE
feat: JWT 토큰에 회원 권한 정보 추가

### DIFF
--- a/src/main/kotlin/site/billilge/api/backend/global/security/jwt/TokenProvider.kt
+++ b/src/main/kotlin/site/billilge/api/backend/global/security/jwt/TokenProvider.kt
@@ -10,6 +10,7 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication
 import org.springframework.stereotype.Service
 import site.billilge.api.backend.domain.member.entity.Member
+import site.billilge.api.backend.domain.member.enums.Role
 import site.billilge.api.backend.global.security.UserAuthInfoService
 import java.security.Key
 import java.time.Duration
@@ -33,10 +34,10 @@ class TokenProvider(
 
     fun generateToken(member: Member, expiredAt: Duration): String {
         val now = Date()
-        return makeToken(Date(now.time + expiredAt.toMillis()), member.studentId)
+        return makeToken(Date(now.time + expiredAt.toMillis()), member.studentId, member.role)
     }
 
-    private fun makeToken(expiry: Date, studentId: String): String {
+    private fun makeToken(expiry: Date, studentId: String, role: Role): String {
         val now = Date()
 
         return Jwts.builder()
@@ -45,6 +46,7 @@ class TokenProvider(
             .setIssuedAt(now)
             .setExpiration(expiry)
             .setSubject(studentId)
+            .claim("role", role.name)
             .signWith(createSecretKey(), signatureAlgorithm)
             .compact()
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#35 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

소셜 로그인 성공 시에 바로 프론트 URL로 연결시키다보니 정보를 응답 객체의 body나 쿠키로 전달하는 게 불가능했습니다.
그렇다고 URL의 쿼리 파라미터로 유저 권한 정보를 보내기엔 위조를 막기 힘들 것 같습니다.
그래서 JWT에 회원 권한 정보를 담아 토큰을 생성하는 방식으로 권한 정보를 전달하는 방식을 채택했습니다!
@sinji2102 참고 부탁드려요!

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
