### PR TITLE
refactor: RentalHistoryDetail에 member와 item 이름 오류 수정

### DIFF
--- a/src/main/kotlin/site/billilge/api/backend/domain/rental/dto/response/RentalHistoryDetail.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/rental/dto/response/RentalHistoryDetail.kt
@@ -13,9 +13,9 @@ data class RentalHistoryDetail(
     @field:Schema(description = "대여 이력 ID", example = "123")
     val rentalHistoryId: Long,
     @field:Schema(description = "대여한 회원의 요약 정보", required = true)
-    val memberId: MemberSummary,
+    val member: MemberSummary,
     @field:Schema(description = "대여한 물품의 요약 정보", required = true)
-    val itemId: ItemSummary,
+    val item: ItemSummary,
     @field:Schema(description = "대여 시작 시각")
     val rentAt: LocalDateTime,
     @field:Schema(description = "반납 시각 (반납되지 않았으면 null)")
@@ -28,8 +28,8 @@ data class RentalHistoryDetail(
         fun from(rentalHistory: RentalHistory): RentalHistoryDetail {
             return RentalHistoryDetail(
                 rentalHistoryId = rentalHistory.id!!,
-                memberId = MemberSummary.from(rentalHistory.member),
-                itemId = ItemSummary.from(rentalHistory.item),
+                member = MemberSummary.from(rentalHistory.member),
+                item = ItemSummary.from(rentalHistory.item),
                 rentAt = rentalHistory.rentAt,
                 returnedAt = rentalHistory.returnedAt,
                 rentalStatus = rentalHistory.rentalStatus


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#54 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

RentalHistoryDetail에서 memberId와 itemId로 표기 오류된 것을 수정하였습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
