### PR TITLE
fix: Swagger에서 multipart/form-data API 사용이 불가능하던 오류 수정 완료

### DIFF
--- a/src/main/kotlin/site/billilge/api/backend/domain/item/controller/AdminItemApi.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/item/controller/AdminItemApi.kt
@@ -2,10 +2,13 @@ package site.billilge.api.backend.domain.item.controller
 
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Encoding
 import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.parameters.RequestBody
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.ModelAttribute
 import org.springframework.web.bind.annotation.PathVariable
@@ -54,6 +57,12 @@ interface AdminItemApi {
             )
         ]
     )
+    @RequestBody(
+        content = [Content(
+            encoding = [
+                Encoding(name = "itemRequest", contentType = MediaType.APPLICATION_JSON_VALUE)]
+        )]
+    )
     fun addItem(@RequestPart image: MultipartFile, @RequestPart itemRequest: ItemRequest): ResponseEntity<Void>
 
     @Operation(
@@ -72,6 +81,12 @@ interface AdminItemApi {
                 content = [Content(schema = Schema(implementation = ErrorResponse::class))]
             )
         ]
+    )
+    @RequestBody(
+        content = [Content(
+            encoding = [
+                Encoding(name = "itemRequest", contentType = MediaType.APPLICATION_JSON_VALUE)]
+        )]
     )
     fun updateItem(
         @PathVariable itemId: Long,


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#58 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

Swagger에서 물품 등록 및 수정이 불가능하던 오류를 수정했습니다.
multipart/form-data API로 요청을 보낼 때 각 data의 content-type을 지정해줘야 하는데, 지정해주지 않을 경우 multipart/octet-stream으로 바뀌어서 요청을 보내게 됩니다.
이 현상을 수정했습니다!

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
