### PR TITLE
feat: 알림 조회, 읽음 API 구현

### DIFF
--- a/src/main/kotlin/site/billilge/api/backend/domain/notification/controller/NotificationApi.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/notification/controller/NotificationApi.kt
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.PathVariable
 import site.billilge.api.backend.domain.notification.dto.response.NotificationFindAllResponse
 import site.billilge.api.backend.global.security.oauth2.UserAuthInfo
 
@@ -27,4 +28,21 @@ interface NotificationApi {
     fun getNotifications(
         @AuthenticationPrincipal userAuthInfo: UserAuthInfo
     ): ResponseEntity<NotificationFindAllResponse>
+
+
+    @Operation(
+        summary = "알림 읽음 처리",
+        description = "사용자가 특정 알림을 읽음 처리합니다."
+    )
+    @ApiResponses(
+        value =  [
+            ApiResponse(responseCode = "200", description = "알림 읽음 처리 완료"),
+            ApiResponse(responseCode = "403", description = "권한이 없는 사용자"),
+            ApiResponse(responseCode = "404", description = "알림을 찾을 수 없음")
+        ]
+    )
+    fun readNotification(
+        @AuthenticationPrincipal userAuthInfo: UserAuthInfo,
+        @PathVariable notificationId: Long
+    ): ResponseEntity<Void>
 }

--- a/src/main/kotlin/site/billilge/api/backend/domain/notification/controller/NotificationApi.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/notification/controller/NotificationApi.kt
@@ -1,0 +1,30 @@
+package site.billilge.api.backend.domain.notification.api
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import site.billilge.api.backend.domain.notification.dto.response.NotificationFindAllResponse
+import site.billilge.api.backend.global.security.oauth2.UserAuthInfo
+
+@Tag(name = "Notification", description = "알림 API")
+interface NotificationApi {
+
+    @Operation(
+        summary = "사용자의 알림 목록 조회",
+        description = "로그인한 사용자의 알림 목록을 최신순으로 조회합니다."
+    )
+    @ApiResponses(
+        value =  [
+            ApiResponse(
+                responseCode =  "200",
+                description = "알림 목록 조회 성공"
+            )
+        ]
+    )
+    fun getNotifications(
+        @AuthenticationPrincipal userAuthInfo: UserAuthInfo
+    ): ResponseEntity<NotificationFindAllResponse>
+}

--- a/src/main/kotlin/site/billilge/api/backend/domain/notification/controller/NotificationController.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/notification/controller/NotificationController.kt
@@ -2,9 +2,7 @@ package site.billilge.api.backend.domain.notification.controller
 
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 import site.billilge.api.backend.domain.notification.api.NotificationApi
 import site.billilge.api.backend.domain.notification.dto.response.NotificationFindAllResponse
 import site.billilge.api.backend.domain.notification.service.NotificationService
@@ -22,5 +20,15 @@ class NotificationController (
     ): ResponseEntity<NotificationFindAllResponse> {
         val memberId = userAuthInfo.memberId
         return ResponseEntity.ok(notificationService.getNotifications(memberId))
+    }
+
+    @PatchMapping("/{notificationId}")
+    override fun readNotification(
+        @AuthenticationPrincipal userAuthInfo: UserAuthInfo,
+        @PathVariable notificationId: Long
+    ): ResponseEntity<Void> {
+        val memberId = userAuthInfo.memberId
+        notificationService.readNotification(memberId, notificationId)
+        return ResponseEntity.ok().build()
     }
 }

--- a/src/main/kotlin/site/billilge/api/backend/domain/notification/controller/NotificationController.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/notification/controller/NotificationController.kt
@@ -1,0 +1,26 @@
+package site.billilge.api.backend.domain.notification.controller
+
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import site.billilge.api.backend.domain.notification.api.NotificationApi
+import site.billilge.api.backend.domain.notification.dto.response.NotificationFindAllResponse
+import site.billilge.api.backend.domain.notification.service.NotificationService
+import site.billilge.api.backend.global.security.oauth2.UserAuthInfo
+
+@RestController
+@RequestMapping("/notifications")
+class NotificationController (
+    private val notificationService: NotificationService
+): NotificationApi {
+
+    @GetMapping
+    override fun getNotifications(
+        @AuthenticationPrincipal userAuthInfo: UserAuthInfo
+    ): ResponseEntity<NotificationFindAllResponse> {
+        val memberId = userAuthInfo.memberId
+        return ResponseEntity.ok(notificationService.getNotifications(memberId))
+    }
+}

--- a/src/main/kotlin/site/billilge/api/backend/domain/notification/dto/response/NotificationDetail.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/notification/dto/response/NotificationDetail.kt
@@ -2,7 +2,7 @@ package site.billilge.api.backend.domain.notification.dto.response
 
 import site.billilge.api.backend.domain.notification.entity.Notification
 import site.billilge.api.backend.domain.notification.enums.NotificationType
-import java.time.Instant
+import java.time.LocalDateTime
 
 data class NotificationDetail(
     val notificationId: Long,
@@ -10,7 +10,7 @@ data class NotificationDetail(
     val message: String,
     val link: String,
     val isRead: Boolean,
-    val createdAt: Instant
+    val createdAt: LocalDateTime
 ) {
     companion object {
         fun from(notification: Notification): NotificationDetail {

--- a/src/main/kotlin/site/billilge/api/backend/domain/notification/dto/response/NotificationDetail.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/notification/dto/response/NotificationDetail.kt
@@ -1,0 +1,27 @@
+package site.billilge.api.backend.domain.notification.dto.response
+
+import site.billilge.api.backend.domain.notification.entity.Notification
+import site.billilge.api.backend.domain.notification.enums.NotificationType
+import java.time.Instant
+
+data class NotificationDetail(
+    val notificationId: Long,
+    val type: NotificationType,
+    val message: String,
+    val link: String,
+    val isRead: Boolean,
+    val createdAt: Instant
+) {
+    companion object {
+        fun from(notification: Notification): NotificationDetail {
+            return NotificationDetail(
+                notificationId = notification.id!!,
+                type = notification.type,
+                message = notification.message,
+                link = notification.link,
+                isRead = notification.isRead,
+                createdAt = notification.createdAt
+            )
+        }
+    }
+}

--- a/src/main/kotlin/site/billilge/api/backend/domain/notification/dto/response/NotificationFindAllResponse.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/notification/dto/response/NotificationFindAllResponse.kt
@@ -1,0 +1,5 @@
+package site.billilge.api.backend.domain.notification.dto.response
+
+data class NotificationFindAllResponse(
+    val notificationService: List<NotificationDetail>
+)

--- a/src/main/kotlin/site/billilge/api/backend/domain/notification/dto/response/NotificationFindAllResponse.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/notification/dto/response/NotificationFindAllResponse.kt
@@ -1,5 +1,5 @@
 package site.billilge.api.backend.domain.notification.dto.response
 
 data class NotificationFindAllResponse(
-    val notificationService: List<NotificationDetail>
+    val messages: List<NotificationDetail>
 )

--- a/src/main/kotlin/site/billilge/api/backend/domain/notification/entitiy/Notification.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/notification/entitiy/Notification.kt
@@ -1,11 +1,11 @@
 package site.billilge.api.backend.domain.notification.entity
 
 import jakarta.persistence.*
+import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
 import site.billilge.api.backend.domain.member.entity.Member
 import site.billilge.api.backend.domain.notification.enums.NotificationType
 import java.time.LocalDateTime
-import java.time.ZoneId
 
 @Entity
 @Table(name = "notifications")
@@ -28,8 +28,9 @@ class Notification(
     @Column(name = "is_read", nullable = false, columnDefinition = "TINYINT(1)")
     var isRead: Boolean = false,
 
+    @CreatedDate
     @Column(name = "created_at", nullable = false)
-    val createdAt: LocalDateTime = LocalDateTime.now(ZoneId.of("Asia/Seoul"))
+    val createdAt: LocalDateTime = LocalDateTime.now()
 ) {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/kotlin/site/billilge/api/backend/domain/notification/entitiy/Notification.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/notification/entitiy/Notification.kt
@@ -1,12 +1,15 @@
 package site.billilge.api.backend.domain.notification.entity
 
 import jakarta.persistence.*
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
 import site.billilge.api.backend.domain.member.entity.Member
 import site.billilge.api.backend.domain.notification.enums.NotificationType
-import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneId
 
 @Entity
 @Table(name = "notifications")
+@EntityListeners(AuditingEntityListener::class)
 class Notification(
     @JoinColumn(name = "member_id", nullable = false)
     @ManyToOne
@@ -26,10 +29,14 @@ class Notification(
     var isRead: Boolean = false,
 
     @Column(name = "created_at", nullable = false)
-    val createdAt: Instant = Instant.now()
+    val createdAt: LocalDateTime = LocalDateTime.now(ZoneId.of("Asia/Seoul"))
 ) {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "notification_id")
     val id: Long? = null
+
+    fun readNotification() {
+        this.isRead = true
+    }
 }

--- a/src/main/kotlin/site/billilge/api/backend/domain/notification/entitiy/Notification.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/notification/entitiy/Notification.kt
@@ -1,0 +1,35 @@
+package site.billilge.api.backend.domain.notification.entity
+
+import jakarta.persistence.*
+import site.billilge.api.backend.domain.member.entity.Member
+import site.billilge.api.backend.domain.notification.enums.NotificationType
+import java.time.Instant
+
+@Entity
+@Table(name = "notifications")
+class Notification(
+    @JoinColumn(name = "member_id", nullable = false)
+    @ManyToOne
+    val member: Member,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false)
+    val type: NotificationType,
+
+    @Column(name = "message", nullable = false)
+    val message: String,
+
+    @Column(name = "link", nullable = false)
+    val link: String,
+
+    @Column(name = "is_read", nullable = false)
+    var isRead: Boolean = false,
+
+    @Column(name = "created_at", nullable = false)
+    val createdAt: Instant = Instant.now()
+) {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "notification_id")
+    val id: Long? = null
+}

--- a/src/main/kotlin/site/billilge/api/backend/domain/notification/entitiy/Notification.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/notification/entitiy/Notification.kt
@@ -25,7 +25,7 @@ class Notification(
     @Column(name = "link", nullable = false)
     val link: String,
 
-    @Column(name = "is_read", nullable = false)
+    @Column(name = "is_read", nullable = false, columnDefinition = "TINYINT(1)")
     var isRead: Boolean = false,
 
     @Column(name = "created_at", nullable = false)

--- a/src/main/kotlin/site/billilge/api/backend/domain/notification/enums/NotificationType.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/notification/enums/NotificationType.kt
@@ -1,0 +1,13 @@
+package site.billilge.api.backend.domain.notification.enums
+
+enum class NotificationType {
+    ADMIN_RENTAL_APPLY,
+    ADMIN_RENTAL_CANCEL,
+    ADMIN_RETURN_APPLY,
+    ADMIN_RETURN_CANCEL,
+    USER_RENTAL_APPLY,
+    USER_RENTAL_APPROVED,
+    USER_RENTAL_REJECTED,
+    USER_RETURN_APPLY,
+    USER_RETURN_COMPLETED
+}

--- a/src/main/kotlin/site/billilge/api/backend/domain/notification/exception/NotificationErrorCode.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/notification/exception/NotificationErrorCode.kt
@@ -1,0 +1,12 @@
+package site.billilge.api.backend.domain.notification.exception
+
+import org.springframework.http.HttpStatus
+import site.billilge.api.backend.global.exception.ErrorCode
+
+enum class NotificationErrorCode(
+    override val message: String,
+    override val httpStatus: HttpStatus
+) : ErrorCode {
+    NOTIFICATION_NOT_FOUND("알림 정보를 찾을 없습니다.", HttpStatus.NOT_FOUND),
+    NOTIFICATION_ACCESS_DENIED("알림을 수정할 권한이 없습니다.", HttpStatus.FORBIDDEN)
+}

--- a/src/main/kotlin/site/billilge/api/backend/domain/notification/exception/NotificationErrorCode.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/notification/exception/NotificationErrorCode.kt
@@ -7,6 +7,6 @@ enum class NotificationErrorCode(
     override val message: String,
     override val httpStatus: HttpStatus
 ) : ErrorCode {
-    NOTIFICATION_NOT_FOUND("알림 정보를 찾을 없습니다.", HttpStatus.NOT_FOUND),
+    NOTIFICATION_NOT_FOUND("알림 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     NOTIFICATION_ACCESS_DENIED("알림을 수정할 권한이 없습니다.", HttpStatus.FORBIDDEN)
 }

--- a/src/main/kotlin/site/billilge/api/backend/domain/notification/repository/NotificationRepository.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/notification/repository/NotificationRepository.kt
@@ -1,0 +1,8 @@
+package site.billilge.api.backend.domain.notification.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import site.billilge.api.backend.domain.notification.entity.Notification
+
+interface NotificationRepository : JpaRepository<Notification, Long> {
+    fun findByMemberIdAndIsReadFalseOrderByCreatedAtDesc(memberId: Long): List<Notification>
+}

--- a/src/main/kotlin/site/billilge/api/backend/domain/notification/service/NotificationService.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/notification/service/NotificationService.kt
@@ -4,7 +4,9 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import site.billilge.api.backend.domain.notification.dto.response.NotificationDetail
 import site.billilge.api.backend.domain.notification.dto.response.NotificationFindAllResponse
+import site.billilge.api.backend.domain.notification.exception.NotificationErrorCode
 import site.billilge.api.backend.domain.notification.repository.NotificationRepository
+import site.billilge.api.backend.global.exception.ApiException
 
 @Service
 @Transactional(readOnly = true)
@@ -16,5 +18,18 @@ class NotificationService(
 
         return NotificationFindAllResponse(notifications
             .map { NotificationDetail.from(it) })
+    }
+
+    @Transactional
+    fun readNotification(memberId: Long?, notificationId: Long) {
+        val notification = notificationRepository.findById(notificationId)
+            .orElseThrow { ApiException(NotificationErrorCode.NOTIFICATION_NOT_FOUND) }
+
+        if (notification.member.id != memberId) {
+            throw ApiException(NotificationErrorCode.NOTIFICATION_ACCESS_DENIED)
+        }
+
+        notification.readNotification()
+        notificationRepository.save(notification)
     }
 }

--- a/src/main/kotlin/site/billilge/api/backend/domain/notification/service/NotificationService.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/notification/service/NotificationService.kt
@@ -30,6 +30,5 @@ class NotificationService(
         }
 
         notification.readNotification()
-        notificationRepository.save(notification)
     }
 }

--- a/src/main/kotlin/site/billilge/api/backend/domain/notification/service/NotificationService.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/notification/service/NotificationService.kt
@@ -1,0 +1,20 @@
+package site.billilge.api.backend.domain.notification.service
+
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import site.billilge.api.backend.domain.notification.dto.response.NotificationDetail
+import site.billilge.api.backend.domain.notification.dto.response.NotificationFindAllResponse
+import site.billilge.api.backend.domain.notification.repository.NotificationRepository
+
+@Service
+@Transactional(readOnly = true)
+class NotificationService(
+    private val notificationRepository: NotificationRepository
+) {
+    fun getNotifications(memberId: Long?): NotificationFindAllResponse {
+        val notifications = notificationRepository.findByMemberIdAndIsReadFalseOrderByCreatedAtDesc(memberId!!)
+
+        return NotificationFindAllResponse(notifications
+            .map { NotificationDetail.from(it) })
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#63 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 사용자가 읽지 않은 알림 목록을 조회하는 API를 구현했습니다.
- 사용자가 특정 알림을 읽음 처리하는 API를 구현했습니다.


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
