### PR TITLE
feat: FCM 푸시 알림 세팅 및 구현

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -19,6 +19,12 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
+      - name: Create Firebase Config Directory
+        run: |
+          mkdir -p src/main/resources/firebase
+          echo "${{ secrets.FIREBASE_SERVICE_KEY }}" | base64 --decode > src/main/resources/firebase/firebaseServiceKey.json
+        shell: bash
+
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -59,6 +59,8 @@ dependencies {
 
     implementation("io.github.oshai:kotlin-logging-jvm:7.0.3")
 
+    implementation("com.google.firebase:firebase-admin:9.4.3")
+
     compileOnly("org.projectlombok:lombok")
     runtimeOnly("com.h2database:h2")
     runtimeOnly("com.mysql:mysql-connector-j")

--- a/src/main/kotlin/site/billilge/api/backend/domain/member/controller/MemberApi.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/member/controller/MemberApi.kt
@@ -1,0 +1,31 @@
+package site.billilge.api.backend.domain.member.controller
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.RequestBody
+import site.billilge.api.backend.domain.member.dto.request.MemberFCMTokenRequest
+import site.billilge.api.backend.global.security.oauth2.UserAuthInfo
+
+@Tag(name = "Member", description = "회원 API")
+interface MemberApi {
+    @Operation(
+        summary = "FCM 토큰 전송",
+        description = "서버 측으로 회원 기기의 FCM 토큰을 전송하는 API"
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "FCM 토큰 전송 성공"
+            )
+        ]
+    )
+    fun setFCMToken(
+        @AuthenticationPrincipal userAuthInfo: UserAuthInfo,
+        @RequestBody request: MemberFCMTokenRequest
+    ): ResponseEntity<Void>
+}

--- a/src/main/kotlin/site/billilge/api/backend/domain/member/controller/MemberController.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/member/controller/MemberController.kt
@@ -1,0 +1,26 @@
+package site.billilge.api.backend.domain.member.controller
+
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import site.billilge.api.backend.domain.member.dto.request.MemberFCMTokenRequest
+import site.billilge.api.backend.domain.member.service.MemberService
+import site.billilge.api.backend.global.security.oauth2.UserAuthInfo
+
+@RestController
+@RequestMapping("/members")
+class MemberController(
+    private val memberService: MemberService,
+) : MemberApi {
+    @PostMapping("/me/fcm-token")
+    override fun setFCMToken(
+        @AuthenticationPrincipal userAuthInfo: UserAuthInfo,
+        @RequestBody request: MemberFCMTokenRequest
+    ): ResponseEntity<Void> {
+        memberService.setMemberFCMToken(userAuthInfo.memberId, request)
+        return ResponseEntity.ok().build()
+    }
+}

--- a/src/main/kotlin/site/billilge/api/backend/domain/member/dto/request/MemberFCMTokenRequest.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/member/dto/request/MemberFCMTokenRequest.kt
@@ -1,0 +1,9 @@
+package site.billilge.api.backend.domain.member.dto.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema
+data class MemberFCMTokenRequest(
+    @field:Schema(description = "회원의 디바이스 FCM 토큰")
+    val token: String
+)

--- a/src/main/kotlin/site/billilge/api/backend/domain/member/entity/Member.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/member/entity/Member.kt
@@ -40,6 +40,10 @@ class Member(
     var role: Role = Role.USER
         protected set
 
+    @Column(name = "fcm_token")
+    var fcmToken: String? = null
+        protected set
+
     @CreatedDate
     @Column(name = "created_at", nullable = false)
     var createdAt: LocalDateTime = LocalDateTime.now()
@@ -56,5 +60,9 @@ class Member(
 
     fun updateEmail(email: String) {
         this.email = email
+    }
+
+    fun updateFCMToken(fcmToken: String) {
+        this.fcmToken = fcmToken
     }
 }

--- a/src/main/kotlin/site/billilge/api/backend/domain/member/service/MemberService.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/member/service/MemberService.kt
@@ -2,9 +2,11 @@ package site.billilge.api.backend.domain.member.service
 
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import site.billilge.api.backend.domain.member.dto.request.AdminRequest
+import site.billilge.api.backend.domain.member.dto.request.MemberFCMTokenRequest
 import site.billilge.api.backend.domain.member.dto.request.SignUpRequest
 import site.billilge.api.backend.domain.member.dto.response.*
 import site.billilge.api.backend.domain.member.exception.MemberErrorCode
@@ -117,5 +119,13 @@ class MemberService(
             .map { MemberDetail.from(it) }
 
         return MemberFindAllResponse(memberDetails.toList(), members.totalPages)
+    }
+
+    @Transactional
+    fun setMemberFCMToken(memberId: Long?, request: MemberFCMTokenRequest) {
+        val member = (memberRepository.findByIdOrNull(memberId!!)
+            ?: throw ApiException(MemberErrorCode.MEMBER_NOT_FOUND))
+
+        member.updateFCMToken(request.token)
     }
 }

--- a/src/main/kotlin/site/billilge/api/backend/global/external/fcm/FCMConfig.kt
+++ b/src/main/kotlin/site/billilge/api/backend/global/external/fcm/FCMConfig.kt
@@ -1,0 +1,40 @@
+package site.billilge.api.backend.global.external.fcm
+
+import com.google.auth.oauth2.GoogleCredentials
+import com.google.firebase.FirebaseApp
+import com.google.firebase.FirebaseOptions
+import com.google.firebase.messaging.FirebaseMessaging
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.core.io.ClassPathResource
+import java.io.IOException
+
+
+@Configuration
+class FCMConfig {
+    @Bean
+    @Throws(IOException::class)
+    fun firebaseApp(): FirebaseApp {
+        val serviceAccountStream = ClassPathResource("firebase/firebaseServiceKey.json").inputStream
+
+        val googleCredentials = GoogleCredentials.fromStream(serviceAccountStream)
+            .createScoped(
+                listOf(
+                    "https://www.googleapis.com/auth/firebase.messaging",
+                    "https://www.googleapis.com/auth/cloud-platform"
+                )
+            )
+
+        googleCredentials.refreshIfExpired()
+
+        val options = FirebaseOptions.builder()
+            .setCredentials(googleCredentials)
+            .build()
+        return FirebaseApp.initializeApp(options)
+    }
+
+    @Bean
+    fun firebaseMessaging(firebaseApp: FirebaseApp): FirebaseMessaging {
+        return FirebaseMessaging.getInstance(firebaseApp)
+    }
+}

--- a/src/main/kotlin/site/billilge/api/backend/global/external/fcm/FCMService.kt
+++ b/src/main/kotlin/site/billilge/api/backend/global/external/fcm/FCMService.kt
@@ -1,0 +1,27 @@
+package site.billilge.api.backend.global.external.fcm
+
+import com.google.firebase.messaging.FirebaseMessaging
+import com.google.firebase.messaging.FirebaseMessagingException
+import com.google.firebase.messaging.Message
+import com.google.firebase.messaging.Notification
+import org.springframework.stereotype.Service
+
+@Service
+class FCMService(
+    private val firebaseMessaging: FirebaseMessaging,
+) {
+    @Throws(FirebaseMessagingException::class)
+    fun sendPushNotification(fcmToken: String, title: String, body: String) {
+        val notification = Notification.builder()
+            .setTitle(title)
+            .setBody(body)
+            .build()
+
+        val fcmMessage = Message.builder()
+            .setNotification(notification)
+            .setToken(fcmToken)
+            .build()
+
+        firebaseMessaging.send(fcmMessage)
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#62 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

푸시 알림 전송을 위한 FCM 세팅을 진행하였습니다.
사용자 기기의 FCM 토큰을 얻기 위해 새로운 회원 도메인 API를 추가하였습니다.

- 회원 FCM 토큰 전송 (/members/me/fcm-token) [POST]

DB Member 테이블에 fcm_token 컬럼을 추가하였습니다. 

작동 테스트를 따로 해볼 수 없어서 프론트 측에서 관련 기능이 완성되는 대로 같이 테스트를 해보면 좋을 거 같아요~

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
