### PR TITLE
HOTFIX: 대여 상태를 변경한 관리자 id를 넘겨주지 않아 생긴 오류 수정

### DIFF
--- a/src/main/kotlin/site/billilge/api/backend/domain/rental/controller/AdminRentalController.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/rental/controller/AdminRentalController.kt
@@ -43,7 +43,7 @@ class AdminRentalController(
         @PathVariable rentalHistoryId: Long,
         @RequestBody request: RentalStatusUpdateRequest
     ): ResponseEntity<Void> {
-        rentalService.updateRentalStatus(rentalHistoryId, request)
+        rentalService.updateRentalStatus(userAuthInfo.memberId, rentalHistoryId, request)
         return ResponseEntity.ok().build()
     }
 }

--- a/src/main/kotlin/site/billilge/api/backend/domain/rental/entity/RentalHistory.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/rental/entity/RentalHistory.kt
@@ -57,7 +57,7 @@ class RentalHistory(
         this.rentalStatus = newStatus
     }
 
-    fun setWorker(worker: Member) {
+    fun updateWorker(worker: Member) {
         this.worker = worker
     }
 }

--- a/src/main/kotlin/site/billilge/api/backend/domain/rental/service/RentalService.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/rental/service/RentalService.kt
@@ -215,7 +215,7 @@ class RentalService(
             RentalStatus.CONFIRMED -> {
                 //승인
                 item.subtractCount(rentalHistory.rentedCount)
-                rentalHistory.setWorker(worker)
+                rentalHistory.updateWorker(worker)
 
                 notificationService.sendNotification(
                     renter,


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

대여 상태를 변경했을 때 대여 내역에 근무자 정보를 저장하기 위해 관리자 id를 넘겨줘야 했지만, 코드 수정이 제대로 이루어지지 않아 관리자 id를 받지 못했습니다.
관리자 id를 파라미터로 받도록 수정했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
