### PR TITLE
fix: 대여 승인 시에 물품 수량이 없다면 승인되지 않도록 수정 완료

### DIFF
--- a/src/main/kotlin/site/billilge/api/backend/domain/rental/service/RentalService.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/rental/service/RentalService.kt
@@ -203,11 +203,15 @@ class RentalService(
         val rentalHistory = rentalRepository.findById(rentalHistoryId)
             .orElseThrow { ApiException(RentalErrorCode.RENTAL_NOT_FOUND) }
         val renter = rentalHistory.member
+        val item = rentalHistory.item
+
+        if (request.rentalStatus == RentalStatus.CONFIRMED && item.count <= 0) {
+            throw ApiException(RentalErrorCode.ITEM_OUT_OF_STOCK)
+        }
 
         rentalHistory.updateStatus(request.rentalStatus)
-        val item = rentalHistory.item
-        val itemName = item.name
 
+        val itemName = item.name
         val worker = memberRepository.findById(workerId!!)
             .orElseThrow { ApiException(MemberErrorCode.MEMBER_NOT_FOUND) }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#79 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

대여 승인 시에 물품 수량이 없다면 승인되지 않도록 수정하였습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
