### PR TITLE
feat: 관리자 로그인 API 구현

### DIFF
--- a/src/main/kotlin/site/billilge/api/backend/domain/member/controller/AuthApi.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/member/controller/AuthApi.kt
@@ -1,14 +1,19 @@
 package site.billilge.api.backend.domain.member.controller
 
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestParam
+import site.billilge.api.backend.domain.member.dto.request.AdminLoginRequest
 import site.billilge.api.backend.domain.member.dto.request.SignUpRequest
+import site.billilge.api.backend.domain.member.dto.response.AdminLoginResponse
 import site.billilge.api.backend.domain.member.dto.response.SignUpResponse
+import site.billilge.api.backend.global.exception.ErrorResponse
 
 @Tag(name = "Auth", description = "로그인 인증 API")
 interface AuthApi {
@@ -25,6 +30,35 @@ interface AuthApi {
         ]
     )
     fun signUp(@RequestBody request: SignUpRequest): ResponseEntity<SignUpResponse>
+
+    @Operation(
+        summary = "(관리자 데스크탑) 로그인",
+        description = "관리자 데스크탑 페이지에 접속하기 위한 로그인 API"
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "로그인 성공"
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "회원을 찾을 수 없습니다.",
+                content = [Content(schema = Schema(implementation = ErrorResponse::class))]
+            ),
+            ApiResponse(
+                responseCode = "403",
+                description = "권한이 없습니다.",
+                content = [Content(schema = Schema(implementation = ErrorResponse::class))]
+            ),
+            ApiResponse(
+                responseCode = "400",
+                description = "비밀번호가 일치하지 않습니다.",
+                content = [Content(schema = Schema(implementation = ErrorResponse::class))]
+            )
+        ]
+    )
+    fun loginAdmin(@RequestBody request: AdminLoginRequest): ResponseEntity<AdminLoginResponse>
 
     @Operation(hidden = true)
     fun googleLoginCallback(@RequestParam code: String?): ResponseEntity<Void>

--- a/src/main/kotlin/site/billilge/api/backend/domain/member/controller/AuthController.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/member/controller/AuthController.kt
@@ -7,7 +7,9 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
+import site.billilge.api.backend.domain.member.dto.request.AdminLoginRequest
 import site.billilge.api.backend.domain.member.dto.request.SignUpRequest
+import site.billilge.api.backend.domain.member.dto.response.AdminLoginResponse
 import site.billilge.api.backend.domain.member.dto.response.SignUpResponse
 import site.billilge.api.backend.domain.member.service.MemberService
 
@@ -19,6 +21,11 @@ class AuthController(
     @PostMapping("/auth/sign-up")
     override fun signUp(@RequestBody request: SignUpRequest): ResponseEntity<SignUpResponse> {
         return ResponseEntity.ok(memberService.signUp(request))
+    }
+
+    @PostMapping("/auth/admin-login")
+    override fun loginAdmin(@RequestBody request: AdminLoginRequest): ResponseEntity<AdminLoginResponse> {
+        return ResponseEntity.ok(memberService.loginAdmin(request))
     }
 
     @GetMapping("/login/oauth2/code/google")

--- a/src/main/kotlin/site/billilge/api/backend/domain/member/dto/request/AdminLoginRequest.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/member/dto/request/AdminLoginRequest.kt
@@ -1,0 +1,6 @@
+package site.billilge.api.backend.domain.member.dto.request
+
+data class AdminLoginRequest(
+    val studentId: String,
+    val password: String
+)

--- a/src/main/kotlin/site/billilge/api/backend/domain/member/dto/response/AdminLoginResponse.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/member/dto/response/AdminLoginResponse.kt
@@ -1,0 +1,5 @@
+package site.billilge.api.backend.domain.member.dto.response
+
+data class AdminLoginResponse(
+    val accessToken: String
+)

--- a/src/main/kotlin/site/billilge/api/backend/domain/member/exception/MemberErrorCode.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/member/exception/MemberErrorCode.kt
@@ -10,4 +10,5 @@ enum class MemberErrorCode(
     MEMBER_NOT_FOUND("존재하지 않는 회원입니다.", HttpStatus.BAD_REQUEST),
     EMAIL_ALREADY_EXISTS("이미 존재하는 회원의 이메일입니다.", HttpStatus.BAD_REQUEST),
     FORBIDDEN("접근 권한이 없습니다.", HttpStatus.FORBIDDEN),
+    ADMIN_PASSWORD_MISMATCH("비밀번호가 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
 }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -41,6 +41,7 @@ jwt:
   issuer: ${JWT_ISSUER}
 
 login:
+  admin-password: ${LOGIN_ADMIN_PASSWORD}
   redirect:
     url: ${LOGIN_REDIRECT_URL}
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#81 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

관리자 로그인 API를 구현하였습니다.

- 관리자 로그인 (/auth/admin-login) [GET]

### 스크린샷 (선택)
<img width="1263" alt="스크린샷 2025-02-26 오후 2 20 06" src="https://github.com/user-attachments/assets/e5a182f4-b7e7-4a07-82c3-a4adb2d12b42" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
