### PR TITLE
fix: 알림 개수 API 호출 시 읽지 않은 알림 개수로 보내도록 수정

### DIFF
--- a/src/main/kotlin/site/billilge/api/backend/domain/notification/repository/NotificationRepositoryCustomImpl.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/notification/repository/NotificationRepositoryCustomImpl.kt
@@ -52,6 +52,9 @@ class NotificationRepositoryCustomImpl(
                     .and(
                         notification.status.`in`(USER_TYPE)
                     )
+                    .and(
+                        notification.isRead.isFalse
+                    )
             )
             .fetchOne()?.toInt() ?: 0
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#83 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 알림 개수 API 호출 시에 읽지 않은 알림 개수로 보내도록 수정하였습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
