### PR TITLE
fix: Android에서 FCM 푸시 알림이 간헐적으로 누락되던 오류 수정

### DIFF
--- a/src/main/kotlin/site/billilge/api/backend/global/external/fcm/FCMService.kt
+++ b/src/main/kotlin/site/billilge/api/backend/global/external/fcm/FCMService.kt
@@ -13,6 +13,11 @@ class FCMService(
             .putData("title", title)
             .putData("body", body.replace("\n", " "))
             .putData("link", link)
+            .setAndroidConfig(
+                AndroidConfig.builder()
+                    .setPriority(AndroidConfig.Priority.HIGH)
+                    .build()
+            )
             .setToken(fcmToken)
             .build()
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#90 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

안드로이드에서 간헐적으로 FCM 푸시 알림이 늦게 오던 현상을 우선순위를 높이는 걸로 해결해보려고 합니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?