### PR TITLE
refactor: 관리자 알림 시, 관리자 수만큼 DB에 데이터가 쌓이던 현상 개선 완료

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ application-local.yml
 
 .DS_Store
 /src/main/resources/firebase
+/src/main/resources/payer_insert_queries.sql

--- a/src/main/kotlin/site/billilge/api/backend/domain/member/controller/AdminMemberController.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/member/controller/AdminMemberController.kt
@@ -16,7 +16,6 @@ import site.billilge.api.backend.global.dto.SearchCondition
 class AdminMemberController(
     private val memberService: MemberService
 ) : AdminMemberApi {
-
     @GetMapping
     override fun getAllMembers(
         @ModelAttribute pageableCondition: PageableCondition,

--- a/src/main/kotlin/site/billilge/api/backend/domain/notification/entity/Notification.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/notification/entity/Notification.kt
@@ -11,9 +11,9 @@ import java.time.LocalDateTime
 @Table(name = "notifications")
 @EntityListeners(AuditingEntityListener::class)
 class Notification(
-    @JoinColumn(name = "member_id", nullable = false)
+    @JoinColumn(name = "member_id", nullable = true)
     @ManyToOne
-    val member: Member,
+    val member: Member? = null,
 
     @Enumerated(EnumType.STRING)
     @Column(name = "type", nullable = false)

--- a/src/main/kotlin/site/billilge/api/backend/domain/notification/service/NotificationService.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/notification/service/NotificationService.kt
@@ -30,7 +30,8 @@ class NotificationService(
 
         return NotificationFindAllResponse(
             notifications
-                .map { NotificationDetail.from(it) })
+                .map { NotificationDetail.from(it) }
+        )
     }
 
     @Transactional
@@ -38,7 +39,9 @@ class NotificationService(
         val notification = notificationRepository.findById(notificationId)
             .orElseThrow { ApiException(NotificationErrorCode.NOTIFICATION_NOT_FOUND) }
 
-        if (notification.member.id != memberId) {
+        if (notification.isAdminStatus()) return;
+
+        if (notification.member?.id != memberId) {
             throw ApiException(NotificationErrorCode.NOTIFICATION_ACCESS_DENIED)
         }
 
@@ -58,7 +61,7 @@ class NotificationService(
         member: Member,
         status: NotificationStatus,
         formatValues: List<String>,
-        needPush: Boolean = false
+        needPush: Boolean = false,
     ) {
         val notification = Notification(
             member = member,
@@ -69,23 +72,32 @@ class NotificationService(
         notificationRepository.save(notification)
 
         if (needPush) {
-            val studentId = member.studentId
-
-            if (member.fcmToken == null) {
-                log.warn { "(studentId=${studentId}) FCM Token is null" }
-                return
-            }
-
-            fcmService.sendPushNotification(
-                member.fcmToken!!,
-                status.title,
-                status.formattedMessage(*formatValues.toTypedArray()),
-                status.link,
-                studentId
-            )
+            sendPushNotification(member, status, formatValues)
         }
     }
 
+    private fun sendPushNotification(
+        member: Member,
+        status: NotificationStatus,
+        formatValues: List<String>,
+    ) {
+        val studentId = member.studentId
+
+        if (member.fcmToken == null) {
+            log.warn { "(studentId=${studentId}) FCM Token is null" }
+            return
+        }
+
+        fcmService.sendPushNotification(
+            member.fcmToken!!,
+            status.title,
+            status.formattedMessage(*formatValues.toTypedArray()),
+            status.link,
+            studentId
+        )
+    }
+
+    @Transactional
     fun sendNotificationToAdmin(
         type: NotificationStatus,
         formatValues: List<String>,
@@ -93,8 +105,17 @@ class NotificationService(
     ) {
         val admins = memberRepository.findAllByRole(Role.ADMIN)
 
-        admins.forEach { admin ->
-            sendNotification(admin, type, formatValues, needPush)
+        val notification = Notification(
+            status = type,
+            formatValues = formatValues.joinToString(",")
+        )
+
+        notificationRepository.save(notification)
+
+        if (needPush) {
+            admins.forEach { admin ->
+                sendPushNotification(admin, type, formatValues)
+            }
         }
     }
 
@@ -103,4 +124,6 @@ class NotificationService(
 
         return NotificationCountResponse(count)
     }
+
+    private fun Notification.isAdminStatus(): Boolean = status.name.contains("ADMIN", true)
 }

--- a/src/main/kotlin/site/billilge/api/backend/domain/notification/service/NotificationService.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/notification/service/NotificationService.kt
@@ -69,8 +69,10 @@ class NotificationService(
         notificationRepository.save(notification)
 
         if (needPush) {
+            val studentId = member.studentId
+
             if (member.fcmToken == null) {
-                log.warn { "(studentId=${member.studentId}) FCM Token is null" }
+                log.warn { "(studentId=${studentId}) FCM Token is null" }
                 return
             }
 
@@ -78,7 +80,8 @@ class NotificationService(
                 member.fcmToken!!,
                 status.title,
                 status.formattedMessage(*formatValues.toTypedArray()),
-                status.link
+                status.link,
+                studentId
             )
         }
     }

--- a/src/main/kotlin/site/billilge/api/backend/domain/rental/dto/response/DashboardResponse.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/rental/dto/response/DashboardResponse.kt
@@ -18,8 +18,6 @@ data class DashboardResponse(
         val rentalHistoryId: Long,
         @field:Schema(description = "물품 이름", example = "우산")
         val itemName: String,
-        @field:Schema(description = "물품 타입")
-        val itemType: ItemType,
         @field:Schema(description = "물품 아이콘 URL", example = "https://www.example.com/test.svg")
         val itemImageUrl: String,
         @field:Schema(description = "물품 개수", example = "10")
@@ -39,7 +37,6 @@ data class DashboardResponse(
                 return RentalApplicationDetail(
                     rentalHistoryId = rentalHistory.id!!,
                     itemName = rentalHistory.item.name,
-                    itemType = rentalHistory.item.type,
                     itemImageUrl = rentalHistory.item.imageUrl,
                     rentedCount = rentalHistory.rentedCount,
                     renterName = rentalHistory.member.name,

--- a/src/main/kotlin/site/billilge/api/backend/domain/rental/dto/response/DashboardResponse.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/rental/dto/response/DashboardResponse.kt
@@ -2,6 +2,7 @@ package site.billilge.api.backend.domain.rental.dto.response
 
 import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
+import site.billilge.api.backend.domain.item.enums.ItemType
 import site.billilge.api.backend.domain.rental.entity.RentalHistory
 import site.billilge.api.backend.domain.rental.enums.RentalStatus
 import java.time.LocalDateTime
@@ -17,6 +18,8 @@ data class DashboardResponse(
         val rentalHistoryId: Long,
         @field:Schema(description = "물품 이름", example = "우산")
         val itemName: String,
+        @field:Schema(description = "물품 타입")
+        val itemType: ItemType,
         @field:Schema(description = "물품 아이콘 URL", example = "https://www.example.com/test.svg")
         val itemImageUrl: String,
         @field:Schema(description = "물품 개수", example = "10")
@@ -36,6 +39,7 @@ data class DashboardResponse(
                 return RentalApplicationDetail(
                     rentalHistoryId = rentalHistory.id!!,
                     itemName = rentalHistory.item.name,
+                    itemType = rentalHistory.item.type,
                     itemImageUrl = rentalHistory.item.imageUrl,
                     rentedCount = rentalHistory.rentedCount,
                     renterName = rentalHistory.member.name,

--- a/src/main/kotlin/site/billilge/api/backend/domain/rental/entity/RentalHistory.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/rental/entity/RentalHistory.kt
@@ -31,7 +31,7 @@ class RentalHistory(
     val rentAt: LocalDateTime,
 
     @Column(name = "returned_at", nullable = true)
-    val returnedAt: LocalDateTime? = null,
+    var returnedAt: LocalDateTime? = null,
 
     @Column(name = "rented_count", nullable = false)
     val rentedCount: Int,
@@ -54,6 +54,10 @@ class RentalHistory(
 
 
     fun updateStatus(newStatus: RentalStatus) {
+        if (newStatus == RentalStatus.RETURNED) {
+            returnedAt = LocalDateTime.now()
+        }
+
         this.rentalStatus = newStatus
     }
 

--- a/src/main/kotlin/site/billilge/api/backend/domain/rental/exception/RentalErrorCode.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/rental/exception/RentalErrorCode.kt
@@ -13,6 +13,7 @@ enum class RentalErrorCode(
     RENTAL_ITEM_DUPLICATED("이미 대여 중인 물품입니다.\n중복 대여하시겠습니까?", HttpStatus.CONFLICT),
     INVALID_RENTAL_TIME_OUT_OF_RANGE("대여 가능시간은 10:00 ~ 17:00입니다. 다시 입력해주세요", HttpStatus.BAD_REQUEST),
     INVALID_RENTAL_TIME_PAST("현재 시간보다 이후의 시간으로 설정해주세요", HttpStatus.BAD_REQUEST),
+    INVALID_RENTAL_TIME_WEEKEND("주말에는 대여가 불가능합니다.", HttpStatus.BAD_REQUEST),
     RENTAL_NOT_FOUND("대여 기록을 찾을 수 없습니다", HttpStatus.NOT_FOUND),
     MEMBER_IS_NOT_PAYER("복지물품을 대여하려면 먼저 학생회비를 납부해주세요.", HttpStatus.FORBIDDEN),
 }

--- a/src/main/kotlin/site/billilge/api/backend/domain/rental/service/RentalService.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/rental/service/RentalService.kt
@@ -20,6 +20,7 @@ import site.billilge.api.backend.domain.rental.repository.RentalRepository
 import site.billilge.api.backend.global.dto.PageableCondition
 import site.billilge.api.backend.global.dto.SearchCondition
 import site.billilge.api.backend.global.exception.ApiException
+import site.billilge.api.backend.global.utils.isWeekend
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -68,6 +69,10 @@ class RentalService(
 
         val currentKoreanTime = LocalDateTime.now(koreanZone)
         if (!isDevMode) {
+            if (requestedRentalDateTime.isWeekend) {
+                throw ApiException(RentalErrorCode.INVALID_RENTAL_TIME_WEEKEND)
+            }
+
             if (requestedRentalDateTime.isBefore(currentKoreanTime)) {
                 throw ApiException(RentalErrorCode.INVALID_RENTAL_TIME_PAST)
             }

--- a/src/main/kotlin/site/billilge/api/backend/domain/rental/service/RentalService.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/rental/service/RentalService.kt
@@ -4,6 +4,7 @@ import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import site.billilge.api.backend.domain.item.enums.ItemType
 import site.billilge.api.backend.domain.item.repository.ItemRepository
 import site.billilge.api.backend.domain.member.exception.MemberErrorCode
 import site.billilge.api.backend.domain.member.repository.MemberRepository
@@ -268,6 +269,8 @@ class RentalService(
 
             RentalStatus.RETURNED -> {
                 //반납 완료
+                if (item.type == ItemType.CONSUMPTION) return
+
                 item.addCount(rentalHistory.rentedCount)
                 itemRepository.save(item)
                 notificationService.sendNotification(

--- a/src/main/kotlin/site/billilge/api/backend/domain/rental/service/RentalService.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/rental/service/RentalService.kt
@@ -216,7 +216,12 @@ class RentalService(
             throw ApiException(RentalErrorCode.ITEM_OUT_OF_STOCK)
         }
 
-        rentalHistory.updateStatus(request.rentalStatus)
+        val newStatus =
+            if (request.rentalStatus == RentalStatus.RENTAL && item.type == ItemType.CONSUMPTION)
+                RentalStatus.RETURNED
+            else request.rentalStatus
+
+        rentalHistory.updateStatus(newStatus)
 
         val itemName = item.name
         val worker = memberRepository.findById(workerId!!)
@@ -287,7 +292,12 @@ class RentalService(
     }
 
     companion object {
-        private val DASHBOARD_STATUS = listOf(RentalStatus.PENDING, RentalStatus.RETURN_PENDING, RentalStatus.RETURN_CONFIRMED, RentalStatus.CONFIRMED)
+        private val DASHBOARD_STATUS = listOf(
+            RentalStatus.PENDING,
+            RentalStatus.RETURN_PENDING,
+            RentalStatus.RETURN_CONFIRMED,
+            RentalStatus.CONFIRMED
+        )
         private val RETURN_REQUIRED_STATUS =
             listOf(RentalStatus.RENTAL, RentalStatus.RETURN_PENDING, RentalStatus.RETURN_CONFIRMED)
     }

--- a/src/main/kotlin/site/billilge/api/backend/global/external/fcm/FCMService.kt
+++ b/src/main/kotlin/site/billilge/api/backend/global/external/fcm/FCMService.kt
@@ -18,6 +18,7 @@ class FCMService(
 
         try {
             firebaseMessaging.send(fcmMessage)
+            log.info { "(studentId=${studentId}) FCM Message sent." }
         } catch(exception: FirebaseMessagingException) {
             if (exception.messagingErrorCode == MessagingErrorCode.UNREGISTERED) {
                 log.error { "(studentId=${studentId}) FCM token is unregistered." }

--- a/src/main/kotlin/site/billilge/api/backend/global/external/fcm/FCMService.kt
+++ b/src/main/kotlin/site/billilge/api/backend/global/external/fcm/FCMService.kt
@@ -2,13 +2,13 @@ package site.billilge.api.backend.global.external.fcm
 
 import com.google.firebase.messaging.*
 import org.springframework.stereotype.Service
+import site.billilge.api.backend.global.logging.log
 
 @Service
 class FCMService(
     private val firebaseMessaging: FirebaseMessaging,
 ) {
-    @Throws(FirebaseMessagingException::class)
-    fun sendPushNotification(fcmToken: String, title: String, body: String, link: String) {
+    fun sendPushNotification(fcmToken: String, title: String, body: String, link: String, studentId: String = "20000000") {
         val fcmMessage = Message.builder()
             .putData("title", title)
             .putData("body", body.replace("\n", " "))
@@ -16,6 +16,12 @@ class FCMService(
             .setToken(fcmToken)
             .build()
 
-        firebaseMessaging.send(fcmMessage)
+        try {
+            firebaseMessaging.send(fcmMessage)
+        } catch(exception: FirebaseMessagingException) {
+            if (exception.messagingErrorCode == MessagingErrorCode.UNREGISTERED) {
+                log.error { "(studentId=${studentId}) FCM token is unregistered." }
+            }
+        }
     }
 }

--- a/src/main/kotlin/site/billilge/api/backend/global/external/fcm/FCMService.kt
+++ b/src/main/kotlin/site/billilge/api/backend/global/external/fcm/FCMService.kt
@@ -17,7 +17,7 @@ class FCMService(
             .build()
 
         try {
-            firebaseMessaging.send(fcmMessage)
+            firebaseMessaging.sendAsync(fcmMessage)
             log.info { "(studentId=${studentId}) FCM Message sent." }
         } catch(exception: FirebaseMessagingException) {
             if (exception.messagingErrorCode == MessagingErrorCode.UNREGISTERED) {

--- a/src/main/kotlin/site/billilge/api/backend/global/utils/DateUtils.kt
+++ b/src/main/kotlin/site/billilge/api/backend/global/utils/DateUtils.kt
@@ -1,0 +1,7 @@
+package site.billilge.api.backend.global.utils
+
+import java.time.DayOfWeek
+import java.time.LocalDateTime
+
+val LocalDateTime.isWeekend: Boolean
+    get() = this.dayOfWeek == DayOfWeek.SATURDAY || this.dayOfWeek == DayOfWeek.SUNDAY


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#87 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 관리자 푸쉬 알림을 보낼 때, 관리자 알림 읽음 처리를 위해 관리자 수만큼 DB에 데이터를 쌓던 현상을 개선했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
