### PR TITLE
refactor: 알림 발행 이벤트 기반으로 전환 및 관리자 알림 쿼리 오류 수정

### DIFF
--- a/src/main/kotlin/site/billilge/api/backend/domain/notification/handler/NotificationEventHandler.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/notification/handler/NotificationEventHandler.kt
@@ -1,0 +1,95 @@
+package site.billilge.api.backend.domain.notification.handler
+
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+import site.billilge.api.backend.domain.member.service.MemberService
+import site.billilge.api.backend.domain.notification.enums.NotificationStatus
+import site.billilge.api.backend.domain.notification.service.NotificationService
+import site.billilge.api.backend.domain.rental.enums.RentalStatus
+import site.billilge.api.backend.domain.rental.event.*
+
+@Component
+class NotificationEventHandler(
+    private val notificationService: NotificationService,
+    private val memberService: MemberService,
+) {
+    @Async
+    @Transactional
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun handleRentalApplied(event: RentalAppliedEvent) {
+        val member = memberService.findById(event.memberId)
+
+        notificationService.sendNotification(
+            member,
+            NotificationStatus.USER_RENTAL_APPLY,
+            listOf(event.itemName),
+            needPush = true,
+        )
+
+        if (!event.isDevMode) {
+            notificationService.sendNotificationToAdmin(
+                NotificationStatus.ADMIN_RENTAL_APPLY,
+                listOf(
+                    member.name,
+                    member.studentId,
+                    "%02d:%02d".format(event.rentAt.hour, event.rentAt.minute),
+                    event.itemName,
+                ),
+                needPush = true,
+            )
+        }
+    }
+
+    @Async
+    @Transactional
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun handleRentalCancelled(event: RentalCancelledEvent) {
+        val member = memberService.findById(event.memberId)
+
+        notificationService.sendNotificationToAdmin(
+            NotificationStatus.ADMIN_RENTAL_CANCEL,
+            listOf(member.name, member.studentId, event.itemName),
+            needPush = true,
+        )
+    }
+
+    @Async
+    @Transactional
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun handleReturnApplied(event: ReturnAppliedEvent) {
+        val member = memberService.findById(event.memberId)
+
+        notificationService.sendNotification(
+            member,
+            NotificationStatus.USER_RETURN_APPLY,
+            listOf(event.itemName),
+            needPush = true,
+        )
+
+        notificationService.sendNotificationToAdmin(
+            NotificationStatus.ADMIN_RETURN_APPLY,
+            listOf(member.name, member.studentId, event.itemName),
+            needPush = true,
+        )
+    }
+
+    @Async
+    @Transactional
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun handleRentalStatusChanged(event: RentalStatusChangedEvent) {
+        val member = memberService.findById(event.memberId)
+
+        val (notificationStatus, needPush) = when (event.status) {
+            RentalStatus.CONFIRMED -> NotificationStatus.USER_RENTAL_APPROVED to true
+            RentalStatus.REJECTED -> NotificationStatus.USER_RENTAL_REJECTED to true
+            RentalStatus.RETURN_CONFIRMED -> NotificationStatus.USER_RETURN_APPROVED to true
+            RentalStatus.RETURNED -> NotificationStatus.USER_RETURN_COMPLETED to false
+            else -> return
+        }
+
+        notificationService.sendNotification(member, notificationStatus, listOf(event.itemName), needPush)
+    }
+}

--- a/src/main/kotlin/site/billilge/api/backend/domain/notification/repository/NotificationRepositoryCustomImpl.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/notification/repository/NotificationRepositoryCustomImpl.kt
@@ -32,10 +32,8 @@ class NotificationRepositoryCustomImpl(
             .select(notification)
             .from(notification)
             .where(
-                memberIdEquals(notification, memberId)
-                    .and(
-                        notification.status.`in`(ADMIN_TYPE)
-                    )
+                notification.member.isNull
+                    .and(notification.status.`in`(ADMIN_TYPE))
             )
             .orderBy(notification.createdAt.desc())
             .fetch()

--- a/src/main/kotlin/site/billilge/api/backend/domain/notification/repository/NotificationRepositoryCustomImpl.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/notification/repository/NotificationRepositoryCustomImpl.kt
@@ -69,6 +69,7 @@ class NotificationRepositoryCustomImpl(
             NotificationStatus.USER_RENTAL_APPROVED,
             NotificationStatus.USER_RENTAL_REJECTED,
             NotificationStatus.USER_RETURN_APPLY,
+            NotificationStatus.USER_RETURN_APPROVED,
             NotificationStatus.USER_RETURN_COMPLETED
         )
 

--- a/src/main/kotlin/site/billilge/api/backend/domain/rental/event/RentalEvents.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/rental/event/RentalEvents.kt
@@ -1,0 +1,27 @@
+package site.billilge.api.backend.domain.rental.event
+
+import site.billilge.api.backend.domain.rental.enums.RentalStatus
+import java.time.LocalDateTime
+
+data class RentalAppliedEvent(
+    val memberId: Long,
+    val itemName: String,
+    val rentAt: LocalDateTime,
+    val isDevMode: Boolean,
+)
+
+data class RentalCancelledEvent(
+    val memberId: Long,
+    val itemName: String,
+)
+
+data class ReturnAppliedEvent(
+    val memberId: Long,
+    val itemName: String,
+)
+
+data class RentalStatusChangedEvent(
+    val memberId: Long,
+    val itemName: String,
+    val status: RentalStatus,
+)

--- a/src/main/kotlin/site/billilge/api/backend/domain/rental/service/RentalService.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/rental/service/RentalService.kt
@@ -1,5 +1,6 @@
 package site.billilge.api.backend.domain.rental.service
 
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
@@ -12,14 +13,16 @@ import site.billilge.api.backend.domain.item.enums.ItemType
 import site.billilge.api.backend.domain.member.entity.Member
 import site.billilge.api.backend.domain.member.enums.Role
 import site.billilge.api.backend.domain.member.exception.MemberErrorCode
-import site.billilge.api.backend.domain.notification.enums.NotificationStatus
-import site.billilge.api.backend.domain.notification.service.NotificationService
 import site.billilge.api.backend.domain.rental.entity.RentalHistory
+import site.billilge.api.backend.domain.rental.entity.RentalStatusWorkerLog
 import site.billilge.api.backend.domain.rental.enums.RentalStatus
+import site.billilge.api.backend.domain.rental.event.RentalAppliedEvent
+import site.billilge.api.backend.domain.rental.event.RentalCancelledEvent
+import site.billilge.api.backend.domain.rental.event.RentalStatusChangedEvent
+import site.billilge.api.backend.domain.rental.event.ReturnAppliedEvent
 import site.billilge.api.backend.domain.rental.exception.RentalErrorCode
 import site.billilge.api.backend.domain.rental.repository.RentalRepository
 import site.billilge.api.backend.domain.rental.repository.RentalStatusWorkerLogRepository
-import site.billilge.api.backend.domain.rental.entity.RentalStatusWorkerLog
 import site.billilge.api.backend.global.dto.PageableCondition
 import site.billilge.api.backend.global.dto.SearchCondition
 import site.billilge.api.backend.global.exception.ApiException
@@ -33,7 +36,7 @@ import java.time.ZoneId
 class RentalService(
     private val rentalRepository: RentalRepository,
     private val rentalStatusWorkerLogRepository: RentalStatusWorkerLogRepository,
-    private val notificationService: NotificationService,
+    private val eventPublisher: ApplicationEventPublisher,
     private val configValueService: ConfigValueService,
 ) {
     @Transactional
@@ -62,25 +65,7 @@ class RentalService(
 
         rentalRepository.save(newRental)
 
-        notificationService.sendNotification(
-            rentUser,
-            NotificationStatus.USER_RENTAL_APPLY,
-            listOf(item.name),
-            true
-        )
-
-        if (!isDevMode) {
-            notificationService.sendNotificationToAdmin(
-                NotificationStatus.ADMIN_RENTAL_APPLY,
-                listOf(
-                    rentUser.name,
-                    rentUser.studentId,
-                    "${String.format("%02d", rentAt.hour)}:${String.format("%02d", rentAt.minute)}",
-                    item.name
-                ),
-                true
-            )
-        }
+        eventPublisher.publishEvent(RentalAppliedEvent(rentUser.id!!, item.name, rentAt, isDevMode))
     }
 
     @Transactional
@@ -135,15 +120,7 @@ class RentalService(
 
         rentalHistory.updateStatus(RentalStatus.CANCEL)
 
-        notificationService.sendNotificationToAdmin(
-            NotificationStatus.ADMIN_RENTAL_CANCEL,
-            listOf(
-                renter.name,
-                renter.studentId,
-                rentalHistory.item.name
-            ),
-            true
-        )
+        eventPublisher.publishEvent(RentalCancelledEvent(renter.id!!, rentalHistory.item.name))
     }
 
     @Transactional
@@ -154,24 +131,7 @@ class RentalService(
 
         rentalHistory.updateStatus(RentalStatus.RETURN_PENDING)
 
-        notificationService.sendNotification(
-            renter,
-            NotificationStatus.USER_RETURN_APPLY,
-            listOf(
-                rentalHistory.item.name
-            ),
-            true
-        )
-
-        notificationService.sendNotificationToAdmin(
-            NotificationStatus.ADMIN_RETURN_APPLY,
-            listOf(
-                renter.name,
-                renter.studentId,
-                rentalHistory.item.name
-            ),
-            true
-        )
+        eventPublisher.publishEvent(ReturnAppliedEvent(renter.id!!, rentalHistory.item.name))
     }
 
     fun getReturnRequiredItems(memberId: Long?): List<RentalHistory> {
@@ -218,64 +178,24 @@ class RentalService(
 
         when (rentalHistory.rentalStatus) {
             RentalStatus.CONFIRMED -> {
-                //승인
                 if (rentedCount > item.count) {
                     throw ApiException(RentalErrorCode.ITEM_OUT_OF_STOCK)
                 }
-
                 item.subtractCount(rentalHistory.rentedCount)
                 rentalHistory.updateWorker(worker)
-
-                notificationService.sendNotification(
-                    renter,
-                    NotificationStatus.USER_RENTAL_APPROVED,
-                    listOf(
-                        itemName
-                    ),
-                    true
-                )
-            }
-
-            RentalStatus.REJECTED -> {
-                //대여 반려
-                notificationService.sendNotification(
-                    renter,
-                    NotificationStatus.USER_RENTAL_REJECTED,
-                    listOf(
-                        itemName
-                    ),
-                    true
-                )
-            }
-
-            RentalStatus.RETURN_CONFIRMED -> {
-                //반납 승인
-                notificationService.sendNotification(
-                    renter,
-                    NotificationStatus.USER_RETURN_APPROVED,
-                    listOf(
-                        itemName
-                    ),
-                    true
-                )
             }
 
             RentalStatus.RETURNED -> {
-                //반납 완료
                 if (item.type == ItemType.CONSUMPTION) return
-
                 item.addCount(rentalHistory.rentedCount)
-                notificationService.sendNotification(
-                    renter,
-                    NotificationStatus.USER_RETURN_COMPLETED,
-                    listOf(
-                        itemName
-                    )
-                )
             }
+
+            RentalStatus.REJECTED, RentalStatus.RETURN_CONFIRMED -> Unit
 
             else -> return
         }
+
+        eventPublisher.publishEvent(RentalStatusChangedEvent(renter.id!!, itemName, rentalHistory.rentalStatus))
 
         rentalStatusWorkerLogRepository.save(
             RentalStatusWorkerLog(

--- a/src/main/kotlin/site/billilge/api/backend/global/external/fcm/FCMService.kt
+++ b/src/main/kotlin/site/billilge/api/backend/global/external/fcm/FCMService.kt
@@ -22,11 +22,13 @@ class FCMService(
             .build()
 
         try {
-            firebaseMessaging.sendAsync(fcmMessage)
-            log.info { "(studentId=${studentId}) FCM Message sent." }
-        } catch(exception: FirebaseMessagingException) {
-            if (exception.messagingErrorCode == MessagingErrorCode.UNREGISTERED) {
-                log.error { "(studentId=${studentId}) FCM token is unregistered." }
+            firebaseMessaging.send(fcmMessage)
+            log.info { "(studentId=$studentId) FCM Message sent." }
+        } catch (e: FirebaseMessagingException) {
+            if (e.messagingErrorCode == MessagingErrorCode.UNREGISTERED) {
+                log.error { "(studentId=$studentId) FCM token is unregistered." }
+            } else {
+                log.error { "(studentId=$studentId) FCM send failed: ${e.message}" }
             }
         }
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

- #115

## 📝작업 내용

### 버그 수정

**`USER_RETURN_APPROVED` 알림 누락**
- `NotificationRepositoryCustomImpl`의 `USER_TYPE` 리스트에 `USER_RETURN_APPROVED`가 없어 반납 승인 알림이 저장은 되지만 사용자에게 조회되지 않던 문제 수정

**`FCMService` 예외 처리 정상화**
- `sendAsync()`는 non-blocking으로 `try-catch`가 동작하지 않아 FCM 오류가 완전히 무시되던 문제 수정
- 동기 `send()`로 교체하여 `FirebaseMessagingException` 정상 처리 (비동기 처리는 이벤트 핸들러의 `@Async`에 위임)

**관리자 알림 조회 쿼리 수정**
- 관리자 알림은 `member = null`로 저장되는 공지식 구조인데, 기존 쿼리가 `member.id = memberId` 조건을 사용해 항상 빈 결과를 반환하던 문제 수정
- `member IS NULL` 조건으로 변경

### 리팩토링

**`ApplicationEventPublisher` 기반 알림 발행으로 전환**

`RentalService`가 `NotificationService`를 직접 호출하던 구조를, 도메인 이벤트 발행 방식으로 전환했습니다.

```
[기존]
RentalService → NotificationService.sendNotification() (트랜잭션 내 FCM 호출)

[변경]
RentalService → eventPublisher.publishEvent()
                    ↓ @TransactionalEventListener(AFTER_COMMIT) + @Async
NotificationEventHandler → NotificationService
```

- 트랜잭션 커밋 이후에만 알림 발송 → 롤백 시 불필요한 FCM 푸시 방지
- `RentalService`에서 `NotificationService` 의존 제거
- 이벤트 클래스: `RentalAppliedEvent`, `RentalCancelledEvent`, `ReturnAppliedEvent`, `RentalStatusChangedEvent`

## 💬리뷰 요구사항(선택)
