### PR TITLE
fix: FCM 만료 토큰 미삭제로 인한 알림 유실 처리

### DIFF
--- a/src/main/kotlin/site/billilge/api/backend/domain/member/entity/Member.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/member/entity/Member.kt
@@ -65,4 +65,8 @@ class Member(
     fun updateFCMToken(fcmToken: String) {
         this.fcmToken = fcmToken
     }
+
+    fun clearFCMToken() {
+        this.fcmToken = null
+    }
 }

--- a/src/main/kotlin/site/billilge/api/backend/domain/member/service/MemberService.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/member/service/MemberService.kt
@@ -64,6 +64,7 @@ class MemberService(
             pageableCondition.pageNo,
             pageableCondition.size,
             Sort.by(Sort.Direction.ASC, "studentId")
+                .and(Sort.by(Sort.Direction.ASC, "id"))
         )
         val adminRoles = listOf(Role.ADMIN, Role.WORKER, Role.GA)
         return memberRepository.findAllByRoleInAndNameContaining(adminRoles, searchCondition.search, pageRequest)
@@ -101,6 +102,7 @@ class MemberService(
             pageableCondition.pageNo,
             pageableCondition.size,
             Sort.by(Sort.Direction.ASC, "studentId")
+                .and(Sort.by(Sort.Direction.ASC, "id"))
         )
 
         return if (searchCondition.search.isEmpty()) {
@@ -116,6 +118,12 @@ class MemberService(
             ?: throw ApiException(MemberErrorCode.MEMBER_NOT_FOUND)
 
         member.updateFCMToken(token)
+    }
+
+    @Transactional
+    fun clearFcmToken(memberId: Long) {
+        val member = memberRepository.findByIdOrNull(memberId) ?: return
+        member.clearFCMToken()
     }
 
     fun findById(memberId: Long): Member {

--- a/src/main/kotlin/site/billilge/api/backend/domain/notification/service/NotificationService.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/notification/service/NotificationService.kt
@@ -76,13 +76,17 @@ class NotificationService(
             return
         }
 
-        fcmService.sendPushNotification(
+        val isTokenValid = fcmService.sendPushNotification(
             member.fcmToken!!,
             status.title,
             status.formattedMessage(*formatValues.toTypedArray()),
             status.link,
             studentId
         )
+
+        if (!isTokenValid) {
+            memberService.clearFcmToken(member.id!!)
+        }
     }
 
     @Transactional

--- a/src/main/kotlin/site/billilge/api/backend/global/external/fcm/FCMService.kt
+++ b/src/main/kotlin/site/billilge/api/backend/global/external/fcm/FCMService.kt
@@ -8,7 +8,7 @@ import site.billilge.api.backend.global.logging.log
 class FCMService(
     private val firebaseMessaging: FirebaseMessaging,
 ) {
-    fun sendPushNotification(fcmToken: String, title: String, body: String, link: String, studentId: String = "20000000") {
+    fun sendPushNotification(fcmToken: String, title: String, body: String, link: String, studentId: String = "20000000"): Boolean {
         val fcmMessage = Message.builder()
             .putData("title", title)
             .putData("body", body.replace("\n", " "))
@@ -21,14 +21,17 @@ class FCMService(
             .setToken(fcmToken)
             .build()
 
-        try {
+        return try {
             firebaseMessaging.send(fcmMessage)
             log.info { "(studentId=$studentId) FCM Message sent." }
+            true
         } catch (e: FirebaseMessagingException) {
             if (e.messagingErrorCode == MessagingErrorCode.UNREGISTERED) {
-                log.error { "(studentId=$studentId) FCM token is unregistered." }
+                log.warn { "(studentId=$studentId) FCM token is unregistered. Clearing token." }
+                false
             } else {
                 log.error { "(studentId=$studentId) FCM send failed: ${e.message}" }
+                true
             }
         }
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

- #117

## 📝작업 내용

FCM 토큰이 만료(UNREGISTERED)되었을 때 DB에서 삭제하지 않아, 이후 해당 사용자에게 알림이 영원히 전달되지 않는 문제를 수정합니다.

### 문제 상황

앱 재설치, 장기 미사용 등으로 FCM 토큰은 언제든 무효화될 수 있습니다. 기존 코드에서는 `UNREGISTERED` 에러를 로그만 남기고 넘어가 만료된 토큰이 DB에 계속 남아있었습니다.

### 변경 내용

**`FCMService`**
- `sendPushNotification()` 반환 타입을 `Boolean`으로 변경
- `UNREGISTERED` 에러 시 `false` 반환, 그 외 에러(네트워크 등)는 `true` 반환하여 정상 토큰을 실수로 삭제하지 않도록 분리

**`Member`**
- `clearFCMToken()` 메서드 추가

**`MemberService`**
- `clearFcmToken(memberId)` 메서드 추가

**`NotificationService`**
- FCM 반환값이 `false`이면 `memberService.clearFcmToken()` 호출하여 만료 토큰 즉시 삭제

```
FCM 전송
  └─ UNREGISTERED → false 반환
       └─ NotificationService → memberService.clearFcmToken()
            └─ 이후 알림은 fcmToken == null 체크로 자동 skip
```

## 💬리뷰 요구사항(선택)