### PR TITLE
fix: S3 업로드 성공 후 DB 저장 실패 시 고아 파일 발생 문제 해결

### DIFF
--- a/src/main/kotlin/site/billilge/api/backend/domain/item/service/ItemService.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/item/service/ItemService.kt
@@ -16,6 +16,7 @@ import site.billilge.api.backend.global.dto.SearchCondition
 import site.billilge.api.backend.global.exception.ApiException
 import site.billilge.api.backend.global.exception.GlobalErrorCode
 import site.billilge.api.backend.global.external.FileStorageService
+import site.billilge.api.backend.global.logging.log
 
 @Service
 @Transactional(readOnly = true)
@@ -49,14 +50,13 @@ class ItemService(
         val imageUrl = fileStorageService.uploadImageFile(image)
             ?: throw ApiException(GlobalErrorCode.IMAGE_UPLOAD_FAILED)
 
-        val newItem = Item(
-            name = name,
-            type = type,
-            count = count,
-            imageUrl = imageUrl,
-        )
-
-        itemRepository.save(newItem)
+        try {
+            itemRepository.saveAndFlush(Item(name = name, type = type, count = count, imageUrl = imageUrl))
+        } catch (e: Exception) {
+            runCatching { fileStorageService.deleteImageFile(imageUrl) }
+                .onFailure { log.warn { "Failed to delete orphan image after save failure: $imageUrl" } }
+            throw e
+        }
     }
 
     @Transactional
@@ -64,22 +64,31 @@ class ItemService(
         val item = itemRepository.findById(itemId)
             .orElseThrow { ApiException(ItemErrorCode.ITEM_NOT_FOUND) }
 
-        val imageUrl: String
-
-        if (image == null || image.isEmpty) {
-            imageUrl = item.imageUrl
+        val oldImageUrl = item.imageUrl
+        val newImageUrl: String = if (image == null || image.isEmpty) {
+            oldImageUrl
         } else {
             checkImageIsSvg(image)
-            imageUrl = fileStorageService.uploadImageFile(image)
+            fileStorageService.uploadImageFile(image)
                 ?: throw ApiException(GlobalErrorCode.IMAGE_UPLOAD_FAILED)
         }
 
-        item.update(
-            name = name,
-            type = type,
-            count = count,
-            imageUrl = imageUrl,
-        )
+        item.update(name = name, type = type, count = count, imageUrl = newImageUrl)
+
+        try {
+            itemRepository.saveAndFlush(item)
+        } catch (e: Exception) {
+            if (newImageUrl != oldImageUrl) {
+                runCatching { fileStorageService.deleteImageFile(newImageUrl) }
+                    .onFailure { log.warn { "Failed to delete orphan image after update failure: $newImageUrl" } }
+            }
+            throw e
+        }
+
+        if (newImageUrl != oldImageUrl) {
+            runCatching { fileStorageService.deleteImageFile(oldImageUrl) }
+                .onFailure { log.warn { "Failed to delete replaced image: $oldImageUrl" } }
+        }
     }
 
     @Transactional


### PR DESCRIPTION
## #️⃣연관된 이슈

- #118

## 📝작업 내용

이미지를 스토리지(Minio)에 업로드한 뒤 DB 저장이 실패하면 트랜잭션이 롤백되어도 스토리지 파일은 남아 고아 파일이 누적되는 문제를 수정합니다.

### 문제 상황

스토리지 업로드는 트랜잭션 밖에서 실행되므로 `@Transactional` 롤백 대상이 아닙니다. 기존 코드에서는 `save()` 실패 시 이미 업로드된 파일을 삭제하는 로직이 없었고, `updateItem`에서는 이미지 교체 시 기존 이미지를 삭제하는 로직 자체가 누락되어 있었습니다.

### 변경 내용

**`addItem`**
- `save()` → `saveAndFlush()`로 교체하여 flush를 try-catch 범위 안으로 당김
- DB 저장 실패 시 업로드된 이미지를 보상 삭제

**`updateItem`**
- 동일하게 `saveAndFlush()` 적용하여 새 이미지 보상 삭제 처리
- DB 저장 성공 후 기존 이미지 삭제 로직 추가 (기존에 누락되어 있던 부분)
- 스토리지 삭제 실패는 로그만 남기고 주 흐름에 영향을 주지 않도록 처리

```
[addItem]
업로드 → saveAndFlush
  성공 → 완료
  실패 → 업로드된 이미지 보상 삭제 → 예외 rethrow

[updateItem]
새 이미지 업로드 → saveAndFlush
  성공 → 기존 이미지 삭제
  실패 → 새 이미지 보상 삭제 → 예외 rethrow
```

## 💬리뷰 요구사항(선택)

`saveAndFlush` 후 기존 이미지 삭제가 트랜잭션 커밋 전에 실행됩니다. 삭제 실패 시 `runCatching`으로 로그만 남기고 있는데, 더 엄격하게 처리해야 할지 의견 주시면 감사합니다.