### PR TITLE
feat: 물품 재고 수량 정합성 검증 및 자동 복구 배치 구현

### DIFF
--- a/src/main/kotlin/site/billilge/api/backend/domain/item/batch/StockReconciliationBatch.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/item/batch/StockReconciliationBatch.kt
@@ -1,0 +1,22 @@
+package site.billilge.api.backend.domain.item.batch
+
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import site.billilge.api.backend.domain.item.service.ItemService
+import site.billilge.api.backend.global.logging.log
+
+@Component
+class StockReconciliationBatch(
+    private val itemService: ItemService,
+) {
+    @Scheduled(cron = "0 0 3 * * *")
+    fun reconcile() {
+        log.info { "Stock reconciliation started." }
+        val fixedCount = itemService.reconcileStocks()
+        if (fixedCount == 0) {
+            log.info { "Stock reconciliation completed. No inconsistencies found." }
+        } else {
+            log.warn { "Stock reconciliation completed. Fixed $fixedCount item(s)." }
+        }
+    }
+}

--- a/src/main/kotlin/site/billilge/api/backend/domain/item/entity/Item.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/item/entity/Item.kt
@@ -19,11 +19,21 @@ class Item(
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long? = null
 
+    @Column(name = "total_count", nullable = false)
+    var totalCount: Int = count
+        protected set
+
     fun update(name: String, type: ItemType, count: Int, imageUrl: String?) {
+        val delta = count - this.totalCount
         this.name = name
         this.type = type
-        this.count = count
+        this.totalCount = count
+        this.count = maxOf(0, this.count + delta)
         imageUrl?.let { this.imageUrl = it }
+    }
+
+    fun fixCount(correctedCount: Int) {
+        this.count = maxOf(0, correctedCount)
     }
 
     fun addCount(count: Int) {

--- a/src/main/kotlin/site/billilge/api/backend/domain/item/repository/ItemRepositoryCustom.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/item/repository/ItemRepositoryCustom.kt
@@ -3,7 +3,9 @@ package site.billilge.api.backend.domain.item.repository
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import site.billilge.api.backend.domain.item.repository.dto.ItemWithRentCountQueryResult
+import site.billilge.api.backend.domain.item.repository.dto.StockInconsistencyQueryResult
 
 interface ItemRepositoryCustom {
     fun findAllAsAdminItemDetailByKeyword(keyword: String, pageable: Pageable): Page<ItemWithRentCountQueryResult>
+    fun findStockInconsistencies(): List<StockInconsistencyQueryResult>
 }

--- a/src/main/kotlin/site/billilge/api/backend/domain/item/repository/ItemRepositoryCustomImpl.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/item/repository/ItemRepositoryCustomImpl.kt
@@ -8,9 +8,12 @@ import com.querydsl.jpa.impl.JPAQueryFactory
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.support.PageableExecutionUtils
-import site.billilge.api.backend.domain.item.repository.dto.ItemWithRentCountQueryResult
 import site.billilge.api.backend.domain.item.entity.QItem
+import site.billilge.api.backend.domain.item.enums.ItemType
+import site.billilge.api.backend.domain.item.repository.dto.ItemWithRentCountQueryResult
+import site.billilge.api.backend.domain.item.repository.dto.StockInconsistencyQueryResult
 import site.billilge.api.backend.domain.rental.entity.QRentalHistory
+import site.billilge.api.backend.domain.rental.enums.RentalStatus
 
 class ItemRepositoryCustomImpl(
     private val queryFactory: JPAQueryFactory
@@ -39,6 +42,7 @@ class ItemRepositoryCustomImpl(
             )
             .from(item)
             .where(searchCondition(item, keyword))
+            .orderBy(item.name.asc(), item.id.asc())
             .offset(pageable.offset)
             .limit(pageable.pageSize.toLong())
             .fetch()
@@ -51,7 +55,44 @@ class ItemRepositoryCustomImpl(
         return PageableExecutionUtils.getPage(contents, pageable) { count.fetchOne() ?: 0 }
     }
 
+    override fun findStockInconsistencies(): List<StockInconsistencyQueryResult> {
+        val item = QItem.item
+        val rental = QRentalHistory.rentalHistory
+
+        val activeRentedSum = rental.rentedCount.sum().coalesce(0)
+
+        return queryFactory
+            .select(
+                Projections.constructor(
+                    StockInconsistencyQueryResult::class.java,
+                    item.id,
+                    item.name,
+                    item.count,
+                    item.totalCount,
+                    activeRentedSum,
+                )
+            )
+            .from(item)
+            .leftJoin(rental).on(
+                rental.item.eq(item)
+                    .and(rental.rentalStatus.`in`(STOCK_CONSUMING_STATUSES))
+            )
+            .where(item.type.eq(ItemType.RENTAL))
+            .groupBy(item.id, item.name, item.count, item.totalCount)
+            .having(item.count.ne(item.totalCount.subtract(activeRentedSum)))
+            .fetch()
+    }
+
     private fun searchCondition(item: QItem, keyword: String): BooleanExpression {
         return item.name.like("%${keyword}%")
+    }
+
+    companion object {
+        private val STOCK_CONSUMING_STATUSES = listOf(
+            RentalStatus.CONFIRMED,
+            RentalStatus.RENTAL,
+            RentalStatus.RETURN_PENDING,
+            RentalStatus.RETURN_CONFIRMED,
+        )
     }
 }

--- a/src/main/kotlin/site/billilge/api/backend/domain/item/repository/dto/StockInconsistencyQueryResult.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/item/repository/dto/StockInconsistencyQueryResult.kt
@@ -1,0 +1,9 @@
+package site.billilge.api.backend.domain.item.repository.dto
+
+data class StockInconsistencyQueryResult(
+    val itemId: Long,
+    val itemName: String,
+    val currentCount: Int,
+    val totalCount: Int,
+    val activeRentedSum: Int,
+)

--- a/src/main/kotlin/site/billilge/api/backend/domain/item/service/ItemService.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/item/service/ItemService.kt
@@ -16,6 +16,7 @@ import site.billilge.api.backend.global.dto.SearchCondition
 import site.billilge.api.backend.global.exception.ApiException
 import site.billilge.api.backend.global.exception.GlobalErrorCode
 import site.billilge.api.backend.global.external.FileStorageService
+import site.billilge.api.backend.global.logging.log
 
 @Service
 @Transactional(readOnly = true)
@@ -118,5 +119,22 @@ class ItemService(
     fun getItemById(itemId: Long): Item {
         return itemRepository.findById(itemId)
             .orElseThrow { ApiException(ItemErrorCode.ITEM_NOT_FOUND) }
+    }
+
+    @Transactional
+    fun reconcileStocks(): Int {
+        val inconsistencies = itemRepository.findStockInconsistencies()
+
+        inconsistencies.forEach { result ->
+            val corrected = result.totalCount - result.activeRentedSum
+            log.warn {
+                "Stock inconsistency: item[${result.itemId}] '${result.itemName}' " +
+                "count=${result.currentCount} → $corrected " +
+                "(totalCount=${result.totalCount}, activeRented=${result.activeRentedSum})"
+            }
+            itemRepository.findById(result.itemId).ifPresent { it.fixCount(corrected) }
+        }
+
+        return inconsistencies.size
     }
 }

--- a/src/main/kotlin/site/billilge/api/backend/global/config/AsyncConfig.kt
+++ b/src/main/kotlin/site/billilge/api/backend/global/config/AsyncConfig.kt
@@ -2,8 +2,10 @@ package site.billilge.api.backend.global.config
 
 import org.springframework.context.annotation.Configuration
 import org.springframework.scheduling.annotation.EnableAsync
+import org.springframework.scheduling.annotation.EnableScheduling
 
 @EnableAsync
+@EnableScheduling
 @Configuration
 class AsyncConfig {
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

- #119

## 📝작업 내용

동시성 이슈, 코드 버그, DB 직접 수정 등 다양한 원인으로 `Item.count`와 실제 대여 건수가 어긋날 수 있습니다. 이를 주기적으로 감지하고 자동 복구하는 배치를 구현합니다.

### 핵심 설계

**`totalCount` 필드 도입**

재고 정합성 검증의 기준값으로 `totalCount`(관리자가 설정한 총 재고)를 `Item` 엔티티에 추가했습니다.

```
불일치 조건: item.count ≠ item.totalCount - sum(activeRentals.rentedCount)
복구:        item.count = item.totalCount - sum(activeRentals.rentedCount)
```

대여 중 재고 차감 대상 상태: `CONFIRMED`, `RENTAL`, `RETURN_PENDING`, `RETURN_CONFIRMED`  
※ `CONSUMPTION` 타입은 재고 복원이 없는 별도 회계 모델이므로 검증 대상 제외

**`Item.update()` delta 방식 변경**

관리자가 총 재고를 변경할 때 현재 대여 중인 수량은 그대로 유지되도록 delta를 반영합니다.

```
before: totalCount=5, count=3 (2개 대여 중)
관리자가 총 재고를 8로 변경
after:  totalCount=8, count=6 (2개 대여 중 유지, +3 반영)
```

### 변경 파일

| 파일 | 내용 |
|------|------|
| `Item.kt` | `totalCount` 필드, `update()` delta 방식, `fixCount()` 추가 |
| `StockInconsistencyQueryResult.kt` | 불일치 쿼리 결과 projection DTO |
| `ItemRepositoryCustom/Impl.kt` | `findStockInconsistencies()` QueryDSL 구현 |
| `ItemService.kt` | `reconcileStocks()` — 탐지 + warn 로그 + 자동 복구 |
| `StockReconciliationBatch.kt` | 매일 새벽 3시 `@Scheduled` 실행 |
| `AsyncConfig.kt` | `@EnableScheduling` 추가 |

### 실행 결과 예시

```
[정상] Stock reconciliation completed. No inconsistencies found.
[이상] Stock inconsistency: item[3] '우산' count=5 → 3 (totalCount=10, activeRented=7)
       Stock reconciliation completed. Fixed 1 item(s).
```

## 💬리뷰 요구사항(선택)

`totalCount` 필드 추가로 DB 마이그레이션이 필요합니다. 기존 데이터의 `total_count` 초기값은 생성 시점 `count`와 동일하게 설정됩니다(`var totalCount: Int = count`). 기존 레코드에 대한 마이그레이션 전략이 필요한지 검토 부탁드립니다.