### PR TITLE
fix: 페이지네이션 정렬 기준 미고정으로 인한 결과 중복/누락 수정

### DIFF
--- a/src/main/kotlin/site/billilge/api/backend/domain/payer/repository/PayerRepository.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/payer/repository/PayerRepository.kt
@@ -13,7 +13,7 @@ interface PayerRepository : JpaRepository<Payer, Long?> {
     @Query("select p from Payer p where p.id in :ids")
     fun findAllByIds(@Param("ids") ids: List<Long>): List<Payer>
 
-    @Query("SELECT p FROM Payer p WHERE p.name LIKE CONCAT('%', :name, '%')")
+    @Query("SELECT p FROM Payer p WHERE p.name LIKE CONCAT('%', :name, '%') ORDER BY p.enrollmentYear DESC, p.name")
     fun findAllByNameContaining(@Param("name") name: String, pageable: Pageable): Page<Payer>
 
     fun findAllByEnrollmentYear(enrollmentYear: String): List<Payer>

--- a/src/main/kotlin/site/billilge/api/backend/domain/payer/service/PayerService.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/payer/service/PayerService.kt
@@ -66,6 +66,7 @@ class PayerService(
             pageableCondition.pageNo,
             pageableCondition.size,
             Sort.by(Sort.Direction.DESC, pageableCondition.criteria ?: "enrollmentYear")
+                .and(Sort.by(Sort.Direction.ASC, "id"))
         )
         return payerRepository.findAllByNameContaining(searchCondition.search, pageRequest)
     }

--- a/src/main/kotlin/site/billilge/api/backend/domain/rental/service/RentalService.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/rental/service/RentalService.kt
@@ -151,6 +151,7 @@ class RentalService(
             pageableCondition.pageNo,
             pageableCondition.size,
             Sort.by(Sort.Direction.DESC, pageableCondition.criteria ?: "applicatedAt")
+                .and(Sort.by(Sort.Direction.ASC, "id"))
         )
         return rentalRepository.findAllByMemberNameContaining(searchCondition.search, pageRequest)
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

- #123

## 📝작업 내용

납부자 목록, 대여 이력 페이지네이션 조회 시 정렬 기준 컬럼에 동일한 값을 가진 레코드가 여러 개일 경우, DB가 매 쿼리마다 순서를 다르게 반환해 다음 페이지 조회 시 이전 페이지의 데이터가 중복 노출되거나 일부 데이터가 누락되는 문제를 수정합니다.

### 원인

페이지네이션에서 `LIMIT/OFFSET` 방식은 정렬 순서가 결정적(deterministic)이어야 올바르게 동작합니다. `enrollmentYear`, `applicatedAt` 등은 동일한 값을 가진 레코드가 다수 존재할 수 있어 단독으로는 정렬 기준이 유일하지 않습니다.

### 수정 내용

항상 유일한 값인 `id`를 보조 정렬 기준으로 추가해 정렬 순서를 고정합니다.

| 파일 | 수정 내용 |
|------|-----------|
| `PayerService` | `enrollmentYear DESC` 뒤에 `id ASC` 보조 정렬 추가 |
| `PayerRepository` | `findAllByNameContaining` JPQL에 `ORDER BY enrollmentYear DESC, name` 추가 |
| `RentalService` | `applicatedAt DESC` 뒤에 `id ASC` 보조 정렬 추가 |

## 💬리뷰 요구사항(선택)