### PR TITLE
refactor: [Phase 1] Gradle 멀티모듈 골격 구성

### DIFF
--- a/admin-api/build.gradle.kts
+++ b/admin-api/build.gradle.kts
@@ -1,0 +1,14 @@
+plugins {
+    kotlin("plugin.spring")
+}
+
+dependencies {
+    implementation(project(":core"))
+    implementation(project(":common"))
+
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-validation")
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.1")
+    implementation("org.jetbrains.kotlin:kotlin-reflect")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+}

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -1,0 +1,44 @@
+plugins {
+    kotlin("plugin.spring")
+    id("org.springframework.boot")
+}
+
+configurations {
+    compileOnly {
+        extendsFrom(configurations.annotationProcessor.get())
+    }
+}
+
+dependencies {
+    implementation(project(":admin-api"))
+    implementation(project(":core"))
+    implementation(project(":infra"))
+    implementation(project(":common"))
+
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-security")
+    implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
+    implementation("org.springframework.boot:spring-boot-starter-thymeleaf")
+    implementation("org.springframework.boot:spring-boot-starter-validation")
+    implementation("org.thymeleaf.extras:thymeleaf-extras-springsecurity6")
+
+    implementation("io.jsonwebtoken:jjwt-api:0.11.5")
+    implementation("io.jsonwebtoken:jjwt-impl:0.11.5")
+    implementation("io.jsonwebtoken:jjwt-jackson:0.11.5")
+
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.1")
+    implementation("org.jetbrains.kotlin:kotlin-reflect")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+    implementation("io.github.oshai:kotlin-logging-jvm:7.0.3")
+
+    compileOnly("org.projectlombok:lombok")
+    annotationProcessor("org.projectlombok:lombok")
+
+    runtimeOnly("com.h2database:h2")
+
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
+    testImplementation("org.springframework.security:spring-security-test")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    testRuntimeOnly("com.h2database:h2")
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,99 +1,43 @@
 plugins {
-    kotlin("jvm") version "1.9.25"
-    kotlin("plugin.spring") version "1.9.25"
-    id("org.springframework.boot") version "3.4.1"
-    id("io.spring.dependency-management") version "1.1.6"
-    kotlin("plugin.jpa") version "1.9.25"
-    kotlin("kapt") version "1.9.25"
-    idea
+    kotlin("jvm") version "1.9.25" apply false
+    kotlin("plugin.spring") version "1.9.25" apply false
+    id("org.springframework.boot") version "3.4.1" apply false
+    id("io.spring.dependency-management") version "1.1.6" apply false
+    kotlin("plugin.jpa") version "1.9.25" apply false
+    kotlin("kapt") version "1.9.25" apply false
 }
 
 group = "site.billilge.api"
 version = "0.0.1-SNAPSHOT"
 
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+subprojects {
+    apply(plugin = "org.jetbrains.kotlin.jvm")
+    apply(plugin = "io.spring.dependency-management")
+
+    repositories {
+        mavenCentral()
     }
-}
 
-configurations {
-    compileOnly {
-        extendsFrom(configurations.annotationProcessor.get())
+    configure<io.spring.gradle.dependencymanagement.dsl.DependencyManagementExtension> {
+        imports {
+            mavenBom("org.springframework.boot:spring-boot-dependencies:3.4.1")
+        }
     }
-}
 
-repositories {
-    mavenCentral()
-}
-
-dependencies {
-    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
-    implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
-    implementation("org.springframework.boot:spring-boot-starter-security")
-    implementation("org.springframework.boot:spring-boot-starter-thymeleaf")
-    implementation("org.springframework.boot:spring-boot-starter-validation")
-    implementation("org.springframework.boot:spring-boot-starter-web")
-
-    implementation("io.jsonwebtoken:jjwt-api:0.11.5")
-    implementation("io.jsonwebtoken:jjwt-impl:0.11.5")
-    implementation("io.jsonwebtoken:jjwt-jackson:0.11.5")
-    implementation("org.glassfish.jaxb:jaxb-runtime:2.3.2")
-
-    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.1") // swagger
-
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
-    implementation("org.jetbrains.kotlin:kotlin-reflect")
-
-    implementation("org.thymeleaf.extras:thymeleaf-extras-springsecurity6")
-
-    implementation("io.minio:minio:8.5.7")
-    implementation("javax.xml.bind:jaxb-api:2.3.1")
-    implementation("org.apache.tika:tika-core:2.9.2")
-    implementation("org.apache.tika:tika-parsers-standard-package:2.9.2")
-
-    implementation("com.querydsl:querydsl-jpa:5.0.0:jakarta")
-    kapt("com.querydsl:querydsl-apt:5.0.0:jakarta")
-    kapt("jakarta.annotation:jakarta.annotation-api")
-    kapt("jakarta.persistence:jakarta.persistence-api")
-
-
-    implementation("io.github.oshai:kotlin-logging-jvm:7.0.3")
-
-    implementation("com.google.firebase:firebase-admin:9.4.3")
-
-    compileOnly("org.projectlombok:lombok")
-    runtimeOnly("com.h2database:h2")
-    runtimeOnly("com.mysql:mysql-connector-j")
-    annotationProcessor("org.projectlombok:lombok")
-
-    testImplementation("org.springframework.boot:spring-boot-starter-test")
-    testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
-    testImplementation("org.springframework.security:spring-security-test")
-    runtimeOnly("com.h2database:h2")
-    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
-}
-
-kotlin {
-    compilerOptions {
-        freeCompilerArgs.addAll("-Xjsr305=strict")
+    configure<JavaPluginExtension> {
+        toolchain {
+            languageVersion.set(JavaLanguageVersion.of(21))
+        }
     }
-}
 
-allOpen {
-    annotation("jakarta.persistence.Entity")
-    annotation("jakarta.persistence.MappedSuperclass")
-    annotation("jakarta.persistence.Embeddable")
-}
-
-idea {
-    module {
-        val kaptMain = file("build/generated/source/kapt/main")
-        sourceDirs.add(kaptMain)
-        generatedSourceDirs.add(kaptMain)
+    tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+        kotlinOptions {
+            freeCompilerArgs += "-Xjsr305=strict"
+            jvmTarget = "21"
+        }
     }
-}
 
-tasks.withType<Test> {
-    useJUnitPlatform()
+    tasks.withType<Test> {
+        useJUnitPlatform()
+    }
 }

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -1,0 +1,8 @@
+plugins {
+    kotlin("plugin.spring")
+}
+
+dependencies {
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.jetbrains.kotlin:kotlin-reflect")
+}

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,0 +1,12 @@
+plugins {
+    kotlin("plugin.spring")
+}
+
+dependencies {
+    implementation(project(":common"))
+
+    implementation("org.springframework.boot:spring-boot-starter")
+    implementation("org.springframework.boot:spring-boot-starter-validation")
+    implementation("org.jetbrains.kotlin:kotlin-reflect")
+    annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
+}

--- a/infra/build.gradle.kts
+++ b/infra/build.gradle.kts
@@ -1,0 +1,46 @@
+plugins {
+    kotlin("plugin.spring")
+    kotlin("plugin.jpa")
+    kotlin("kapt")
+    idea
+}
+
+dependencies {
+    implementation(project(":core"))
+    implementation(project(":common"))
+
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation("org.jetbrains.kotlin:kotlin-reflect")
+
+    implementation("com.querydsl:querydsl-jpa:5.0.0:jakarta")
+    kapt("com.querydsl:querydsl-apt:5.0.0:jakarta")
+    kapt("jakarta.annotation:jakarta.annotation-api")
+    kapt("jakarta.persistence:jakarta.persistence-api")
+
+    implementation("com.google.firebase:firebase-admin:9.4.3")
+
+    implementation("io.minio:minio:8.5.7")
+    implementation("javax.xml.bind:jaxb-api:2.3.1")
+    implementation("org.glassfish.jaxb:jaxb-runtime:2.3.2")
+
+    implementation("org.apache.tika:tika-core:2.9.2")
+    implementation("org.apache.tika:tika-parsers-standard-package:2.9.2")
+
+    runtimeOnly("com.mysql:mysql-connector-j")
+    runtimeOnly("com.h2database:h2")
+    annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
+}
+
+allOpen {
+    annotation("jakarta.persistence.Entity")
+    annotation("jakarta.persistence.MappedSuperclass")
+    annotation("jakarta.persistence.Embeddable")
+}
+
+idea {
+    module {
+        val kaptMain = file("build/generated/source/kapt/main")
+        sourceDirs.add(kaptMain)
+        generatedSourceDirs.add(kaptMain)
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,1 +1,2 @@
-rootProject.name = "backend"
+rootProject.name = "billilge-backend"
+include("common", "core", "infra", "admin-api", "api")


### PR DESCRIPTION
## #️⃣연관된 이슈

#126, #127

## 📝작업 내용

> 멀티모듈 리팩터링 Phase 1 — Gradle 골격 구성

소스 코드 이동 없이 5개 모듈의 Gradle 빌드 파일만 작성했습니다.

- \`settings.gradle.kts\`: 루트 프로젝트명 \`billilge-backend\`, 5개 모듈 include
- 루트 \`build.gradle.kts\`: 플러그인 버전 선언(\`apply false\`) + \`subprojects {}\` 공통 설정
  - Spring Boot BOM 3.4.1 적용
  - JVM 툴체인 21, Kotlin 컴파일러 옵션 공통 설정
- 모듈별 \`build.gradle.kts\` 작성
  - \`common\`: spring-web (LoggingFilter용)
  - \`core\`: spring-boot-starter, validation, project(\":common\")
  - \`infra\`: JPA, QueryDSL(kapt), Firebase, Minio, Tika, project(\":core\")
  - \`admin-api\`: spring-web, springdoc, project(\":core\")
  - \`api\`: Spring Boot 진입점, Security, OAuth2, JWT, project(\":admin-api\", \":core\", \":infra\", \":common\")

## 💬리뷰 요구사항(선택)

> 모듈 간 의존성 방향이 계획대로 설정됐는지 확인 부탁드립니다.
> \`api → admin-api → core → common\`, \`api → infra → core\`