### PR TITLE
refactor: [Phase 2] common 모듈 구성

### DIFF
--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -5,4 +5,6 @@ plugins {
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.1")
+    implementation("io.github.oshai:kotlin-logging-jvm:7.0.3")
 }

--- a/common/src/main/kotlin/site/billilge/api/backend/common/exception/ApiException.kt
+++ b/common/src/main/kotlin/site/billilge/api/backend/common/exception/ApiException.kt
@@ -1,4 +1,4 @@
-package site.billilge.api.backend.global.exception
+package site.billilge.api.backend.common.exception
 
 class ApiException(
     val errorCode: ErrorCode = GlobalErrorCode.INTERNAL_SERVER_ERROR,

--- a/common/src/main/kotlin/site/billilge/api/backend/common/exception/ErrorCode.kt
+++ b/common/src/main/kotlin/site/billilge/api/backend/common/exception/ErrorCode.kt
@@ -1,4 +1,4 @@
-package site.billilge.api.backend.global.exception
+package site.billilge.api.backend.common.exception
 
 import org.springframework.http.HttpStatus
 

--- a/common/src/main/kotlin/site/billilge/api/backend/common/exception/ErrorResponse.kt
+++ b/common/src/main/kotlin/site/billilge/api/backend/common/exception/ErrorResponse.kt
@@ -1,8 +1,6 @@
-package site.billilge.api.backend.global.exception
+package site.billilge.api.backend.common.exception
 
-import com.fasterxml.jackson.annotation.JsonFormat
 import io.swagger.v3.oas.annotations.media.Schema
-import java.time.LocalDateTime
 
 @Schema
 data class ErrorResponse(

--- a/common/src/main/kotlin/site/billilge/api/backend/common/exception/GlobalErrorCode.kt
+++ b/common/src/main/kotlin/site/billilge/api/backend/common/exception/GlobalErrorCode.kt
@@ -1,4 +1,4 @@
-package site.billilge.api.backend.global.exception
+package site.billilge.api.backend.common.exception
 
 import org.springframework.http.HttpStatus
 

--- a/common/src/main/kotlin/site/billilge/api/backend/common/logging/LoggingFilter.kt
+++ b/common/src/main/kotlin/site/billilge/api/backend/common/logging/LoggingFilter.kt
@@ -1,4 +1,4 @@
-package site.billilge.api.backend.global.logging
+package site.billilge.api.backend.common.logging
 
 import io.github.oshai.kotlinlogging.KotlinLogging
 import jakarta.servlet.FilterChain

--- a/common/src/main/kotlin/site/billilge/api/backend/common/utils/DateUtils.kt
+++ b/common/src/main/kotlin/site/billilge/api/backend/common/utils/DateUtils.kt
@@ -1,0 +1,7 @@
+package site.billilge.api.backend.common.utils
+
+import java.time.DayOfWeek
+import java.time.LocalDateTime
+
+val LocalDateTime.isWeekend: Boolean
+    get() = this.dayOfWeek == DayOfWeek.SATURDAY || this.dayOfWeek == DayOfWeek.SUNDAY

--- a/common/src/main/kotlin/site/billilge/api/backend/common/utils/ExcelRow.kt
+++ b/common/src/main/kotlin/site/billilge/api/backend/common/utils/ExcelRow.kt
@@ -1,4 +1,4 @@
-package site.billilge.api.backend.global.utils
+package site.billilge.api.backend.common.utils
 
 data class ExcelRow(
     val data: List<String>

--- a/src/main/kotlin/site/billilge/api/backend/global/utils/DateUtils.kt
+++ b/src/main/kotlin/site/billilge/api/backend/global/utils/DateUtils.kt
@@ -1,7 +1,0 @@
-package site.billilge.api.backend.global.utils
-
-import java.time.DayOfWeek
-import java.time.LocalDateTime
-
-val LocalDateTime.isWeekend: Boolean
-    get() = this.dayOfWeek == DayOfWeek.SATURDAY || this.dayOfWeek == DayOfWeek.SUNDAY


### PR DESCRIPTION
## #️⃣연관된 이슈

#126, #128

## 📝작업 내용

> 예외·유틸·로깅 클래스를 `common` 모듈로 이동하고 패키지명을 `global` → `common`으로 변경

- `common/exception/`: `ErrorCode`, `ApiException`, `GlobalErrorCode`, `ErrorResponse`
- `common/logging/`: `LoggingFilter`
- `common/utils/`: `DateUtils`, `ExcelRow`
- `common/build.gradle.kts`에 `springdoc`, `kotlin-logging` 의존성 추가
- 이동된 파일은 `src/`에서 삭제

## 💬리뷰 요구사항(선택)

> `GlobalExceptionHandler`와 `ExcelGenerator`는 각각 Phase 7(api), Phase 5(infra)에서 이동 예정이라 이번 PR에 포함되지 않았습니다.