### PR TITLE
refactor: core 모듈 컨트랙트 레이어 구성 (Phase 3)

### DIFF
--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-    api("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.1")
     implementation("io.github.oshai:kotlin-logging-jvm:7.0.3")

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-    implementation("org.springframework.boot:spring-boot-starter-web")
+    api("org.springframework.boot:spring-boot-starter-web")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.1")
     implementation("io.github.oshai:kotlin-logging-jvm:7.0.3")

--- a/common/src/main/kotlin/site/billilge/api/backend/common/exception/ErrorCode.kt
+++ b/common/src/main/kotlin/site/billilge/api/backend/common/exception/ErrorCode.kt
@@ -1,9 +1,7 @@
 package site.billilge.api.backend.common.exception
 
-import org.springframework.http.HttpStatus
-
 interface ErrorCode {
     val name: String
     val message: String
-    val httpStatus: HttpStatus
+    val status: Int
 }

--- a/common/src/main/kotlin/site/billilge/api/backend/common/exception/ErrorResponse.kt
+++ b/common/src/main/kotlin/site/billilge/api/backend/common/exception/ErrorResponse.kt
@@ -9,26 +9,23 @@ data class ErrorResponse(
     @field:Schema(description = "오류 메시지", example = "오류 메시지입니다.")
     val message: String,
     @field:Schema(description = "HTTP 응답 코드", example = "500")
-    val status: Int
+    val status: Int,
 ) {
     companion object {
         @JvmStatic
-        fun from(errorCode: ErrorCode): ErrorResponse {
-            return ErrorResponse(
-                code = errorCode.name,
-                message = errorCode.message,
-                status = errorCode.httpStatus.value()
-            )
-        }
+        fun from(errorCode: ErrorCode): ErrorResponse = ErrorResponse(
+            code = errorCode.name,
+            message = errorCode.message,
+            status = errorCode.status,
+        )
 
         @JvmStatic
         fun from(exception: Exception): ErrorResponse {
             val errorCode = GlobalErrorCode.INTERNAL_SERVER_ERROR
-
             return ErrorResponse(
                 code = errorCode.name,
                 message = exception.message ?: errorCode.message,
-                status = errorCode.httpStatus.value()
+                status = errorCode.status,
             )
         }
     }

--- a/common/src/main/kotlin/site/billilge/api/backend/common/exception/GlobalErrorCode.kt
+++ b/common/src/main/kotlin/site/billilge/api/backend/common/exception/GlobalErrorCode.kt
@@ -1,17 +1,15 @@
 package site.billilge.api.backend.common.exception
 
-import org.springframework.http.HttpStatus
-
 enum class GlobalErrorCode(
     override val message: String,
-    override val httpStatus: HttpStatus
-): ErrorCode {
-    INTERNAL_SERVER_ERROR("내부 서버 오류입니다.", HttpStatus.INTERNAL_SERVER_ERROR),
-    INVALID_AUTHORIZATION_HEADER("유효하지 않은 Authorization 헤더입니다.", HttpStatus.BAD_REQUEST),
-    FORBIDDEN("접근 권한이 없습니다.", HttpStatus.FORBIDDEN),
-    IMAGE_UPLOAD_FAILED("이미지 업로드에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
-    IMAGE_NOT_FOUND("이미지 파일을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
-    IMAGE_DELETE_FAILED("이미지 삭제에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
-    INVALID_OAUTH2_PROVIDER("유효하지 않은 OAuth2 로그인 인증기관입니다.", HttpStatus.BAD_REQUEST),
-    EXPIRED_ACCESS_TOKEN("만료된 액세스 토큰입니다.", HttpStatus.UNAUTHORIZED),
+    override val status: Int,
+) : ErrorCode {
+    INTERNAL_SERVER_ERROR("내부 서버 오류입니다.", 500),
+    INVALID_AUTHORIZATION_HEADER("유효하지 않은 Authorization 헤더입니다.", 400),
+    FORBIDDEN("접근 권한이 없습니다.", 403),
+    IMAGE_UPLOAD_FAILED("이미지 업로드에 실패했습니다.", 500),
+    IMAGE_NOT_FOUND("이미지 파일을 찾을 수 없습니다.", 404),
+    IMAGE_DELETE_FAILED("이미지 삭제에 실패했습니다.", 500),
+    INVALID_OAUTH2_PROVIDER("유효하지 않은 OAuth2 로그인 인증기관입니다.", 400),
+    EXPIRED_ACCESS_TOKEN("만료된 액세스 토큰입니다.", 401),
 }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     kotlin("plugin.spring")
+    kotlin("kapt")
 }
 
 dependencies {
@@ -7,6 +8,7 @@ dependencies {
 
     implementation("org.springframework.boot:spring-boot-starter")
     implementation("org.springframework.boot:spring-boot-starter-validation")
+    implementation("org.springframework.data:spring-data-commons")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
-    annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
+    kapt("org.springframework.boot:spring-boot-configuration-processor")
 }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -8,7 +8,6 @@ dependencies {
 
     implementation("org.springframework.boot:spring-boot-starter")
     implementation("org.springframework.boot:spring-boot-starter-validation")
-    implementation("org.springframework:spring-web")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     kapt("org.springframework.boot:spring-boot-configuration-processor")
 }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -8,7 +8,6 @@ dependencies {
 
     implementation("org.springframework.boot:spring-boot-starter")
     implementation("org.springframework.boot:spring-boot-starter-validation")
-    implementation("org.springframework.data:spring-data-commons")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     kapt("org.springframework.boot:spring-boot-configuration-processor")
 }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -8,6 +8,7 @@ dependencies {
 
     implementation("org.springframework.boot:spring-boot-starter")
     implementation("org.springframework.boot:spring-boot-starter-validation")
+    implementation("org.springframework:spring-web")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     kapt("org.springframework.boot:spring-boot-configuration-processor")
 }

--- a/core/src/main/kotlin/site/billilge/api/backend/core/config/ExamPeriodProperties.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/core/config/ExamPeriodProperties.kt
@@ -1,0 +1,10 @@
+package site.billilge.api.backend.core.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import java.time.LocalDate
+
+@ConfigurationProperties(prefix = "exam-period")
+data class ExamPeriodProperties(
+    val startDate: LocalDate = LocalDate.of(2000, 1, 1),
+    val endDate: LocalDate = LocalDate.of(2000, 1, 1),
+)

--- a/core/src/main/kotlin/site/billilge/api/backend/core/port/ExcelGeneratorPort.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/core/port/ExcelGeneratorPort.kt
@@ -1,0 +1,10 @@
+package site.billilge.api.backend.core.port
+
+import site.billilge.api.backend.common.utils.ExcelRow
+import java.io.ByteArrayInputStream
+
+interface ExcelGeneratorPort {
+    fun generateByMultipleSheets(
+        sheetData: Map<String, Pair<Array<String>, List<ExcelRow>>>,
+    ): ByteArrayInputStream
+}

--- a/core/src/main/kotlin/site/billilge/api/backend/core/port/FCMPort.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/core/port/FCMPort.kt
@@ -1,0 +1,11 @@
+package site.billilge.api.backend.core.port
+
+interface FCMPort {
+    fun sendPushNotification(
+        fcmToken: String,
+        title: String,
+        body: String,
+        link: String,
+        studentId: String = "20000000",
+    ): Boolean
+}

--- a/core/src/main/kotlin/site/billilge/api/backend/core/port/FileStorageService.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/core/port/FileStorageService.kt
@@ -1,0 +1,27 @@
+package site.billilge.api.backend.core.port
+
+import java.util.UUID
+
+interface FileStorageService {
+    fun uploadImageFile(file: FileUploadRequest, newFileName: String = "items/${UUID.randomUUID()}"): String?
+    fun deleteImageFile(fileName: String)
+}
+
+data class FileUploadRequest(
+    val bytes: ByteArray,
+    val originalFilename: String,
+    val contentType: String,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is FileUploadRequest) return false
+        return bytes.contentEquals(other.bytes) && originalFilename == other.originalFilename && contentType == other.contentType
+    }
+
+    override fun hashCode(): Int {
+        var result = bytes.contentHashCode()
+        result = 31 * result + originalFilename.hashCode()
+        result = 31 * result + contentType.hashCode()
+        return result
+    }
+}

--- a/core/src/main/kotlin/site/billilge/api/backend/core/vo/PageRequest.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/core/vo/PageRequest.kt
@@ -1,0 +1,8 @@
+package site.billilge.api.backend.core.vo
+
+data class PageRequest(
+    val page: Int,
+    val size: Int,
+    val sortBy: String? = null,
+    val ascending: Boolean = false,
+)

--- a/core/src/main/kotlin/site/billilge/api/backend/core/vo/PageResult.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/core/vo/PageResult.kt
@@ -1,0 +1,9 @@
+package site.billilge.api.backend.core.vo
+
+data class PageResult<T>(
+    val content: List<T>,
+    val totalElements: Long,
+    val totalPages: Int,
+    val currentPage: Int,
+    val size: Int,
+)

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/configvalue/entity/ConfigValue.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/configvalue/entity/ConfigValue.kt
@@ -1,0 +1,7 @@
+package site.billilge.api.backend.domain.configvalue.entity
+
+data class ConfigValue(
+    val id: Long?,
+    val key: String,
+    val value: String,
+)

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/configvalue/enums/ConfigValueKeys.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/configvalue/enums/ConfigValueKeys.kt
@@ -1,0 +1,7 @@
+package site.billilge.api.backend.domain.configvalue.enums
+
+enum class ConfigValueKeys(val key: String) {
+    EXAM_PERIOD_START_DATE("exam-period.start-date"),
+    EXAM_PERIOD_END_DATE("exam-period.end-date"),
+    ADMIN_PASSWORD("login.admin-password"),
+}

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/configvalue/exception/ConfigValueErrorCode.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/configvalue/exception/ConfigValueErrorCode.kt
@@ -1,0 +1,12 @@
+package site.billilge.api.backend.domain.configvalue.exception
+
+import org.springframework.http.HttpStatus
+import site.billilge.api.backend.common.exception.ErrorCode
+
+enum class ConfigValueErrorCode(
+    override val message: String,
+    override val httpStatus: HttpStatus,
+) : ErrorCode {
+    CONFIG_VALUE_NOT_FOUND("설정값을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    ADMIN_PASSWORD_MISMATCH("현재 비밀번호가 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
+}

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/configvalue/exception/ConfigValueErrorCode.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/configvalue/exception/ConfigValueErrorCode.kt
@@ -1,12 +1,11 @@
 package site.billilge.api.backend.domain.configvalue.exception
 
-import org.springframework.http.HttpStatus
 import site.billilge.api.backend.common.exception.ErrorCode
 
 enum class ConfigValueErrorCode(
     override val message: String,
-    override val httpStatus: HttpStatus,
+    override val status: Int,
 ) : ErrorCode {
-    CONFIG_VALUE_NOT_FOUND("설정값을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
-    ADMIN_PASSWORD_MISMATCH("현재 비밀번호가 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
+    CONFIG_VALUE_NOT_FOUND("설정값을 찾을 수 없습니다.", 404),
+    ADMIN_PASSWORD_MISMATCH("현재 비밀번호가 일치하지 않습니다.", 400),
 }

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/configvalue/repository/ConfigValueRepository.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/configvalue/repository/ConfigValueRepository.kt
@@ -1,0 +1,10 @@
+package site.billilge.api.backend.domain.configvalue.repository
+
+import site.billilge.api.backend.domain.configvalue.entity.ConfigValue
+
+interface ConfigValueRepository {
+    fun findById(id: Long): ConfigValue?
+    fun findByKey(key: String): ConfigValue?
+    fun findAllByKeyIn(keys: List<String>): List<ConfigValue>
+    fun save(configValue: ConfigValue): ConfigValue
+}

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/display/entity/DisplayCalendarSchedule.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/display/entity/DisplayCalendarSchedule.kt
@@ -1,0 +1,12 @@
+package site.billilge.api.backend.domain.display.entity
+
+import java.time.LocalDate
+
+data class DisplayCalendarSchedule(
+    val id: Long?,
+    val date: LocalDate,
+    val schedules: String,
+) {
+    val scheduleList: List<String>
+        get() = schedules.split("|").map { it.trim() }.filter { it.isNotEmpty() }
+}

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/display/entity/DisplayPoster.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/display/entity/DisplayPoster.kt
@@ -1,0 +1,11 @@
+package site.billilge.api.backend.domain.display.entity
+
+import java.time.LocalDateTime
+
+data class DisplayPoster(
+    val id: Long?,
+    val title: String,
+    val imageUrl: String,
+    val isActive: Boolean = true,
+    val createdAt: LocalDateTime = LocalDateTime.now(),
+)

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/display/exception/DisplayCalendarScheduleErrorCode.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/display/exception/DisplayCalendarScheduleErrorCode.kt
@@ -1,0 +1,11 @@
+package site.billilge.api.backend.domain.display.exception
+
+import org.springframework.http.HttpStatus
+import site.billilge.api.backend.common.exception.ErrorCode
+
+enum class DisplayCalendarScheduleErrorCode(
+    override val message: String,
+    override val httpStatus: HttpStatus,
+) : ErrorCode {
+    SCHEDULE_NOT_FOUND("일정을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+}

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/display/exception/DisplayCalendarScheduleErrorCode.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/display/exception/DisplayCalendarScheduleErrorCode.kt
@@ -1,11 +1,10 @@
 package site.billilge.api.backend.domain.display.exception
 
-import org.springframework.http.HttpStatus
 import site.billilge.api.backend.common.exception.ErrorCode
 
 enum class DisplayCalendarScheduleErrorCode(
     override val message: String,
-    override val httpStatus: HttpStatus,
+    override val status: Int,
 ) : ErrorCode {
-    SCHEDULE_NOT_FOUND("일정을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    SCHEDULE_NOT_FOUND("일정을 찾을 수 없습니다.", 404),
 }

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/display/exception/DisplayPosterErrorCode.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/display/exception/DisplayPosterErrorCode.kt
@@ -1,0 +1,11 @@
+package site.billilge.api.backend.domain.display.exception
+
+import org.springframework.http.HttpStatus
+import site.billilge.api.backend.common.exception.ErrorCode
+
+enum class DisplayPosterErrorCode(
+    override val message: String,
+    override val httpStatus: HttpStatus,
+) : ErrorCode {
+    POSTER_NOT_FOUND("포스터를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+}

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/display/exception/DisplayPosterErrorCode.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/display/exception/DisplayPosterErrorCode.kt
@@ -1,11 +1,10 @@
 package site.billilge.api.backend.domain.display.exception
 
-import org.springframework.http.HttpStatus
 import site.billilge.api.backend.common.exception.ErrorCode
 
 enum class DisplayPosterErrorCode(
     override val message: String,
-    override val httpStatus: HttpStatus,
+    override val status: Int,
 ) : ErrorCode {
-    POSTER_NOT_FOUND("포스터를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    POSTER_NOT_FOUND("포스터를 찾을 수 없습니다.", 404),
 }

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/display/repository/DisplayCalendarScheduleRepository.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/display/repository/DisplayCalendarScheduleRepository.kt
@@ -1,0 +1,12 @@
+package site.billilge.api.backend.domain.display.repository
+
+import site.billilge.api.backend.domain.display.entity.DisplayCalendarSchedule
+import java.time.LocalDate
+
+interface DisplayCalendarScheduleRepository {
+    fun findById(id: Long): DisplayCalendarSchedule?
+    fun findAll(): List<DisplayCalendarSchedule>
+    fun save(schedule: DisplayCalendarSchedule): DisplayCalendarSchedule
+    fun delete(id: Long)
+    fun findByDateBetween(startDate: LocalDate, endDate: LocalDate): List<DisplayCalendarSchedule>
+}

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/display/repository/DisplayPosterRepository.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/display/repository/DisplayPosterRepository.kt
@@ -1,0 +1,11 @@
+package site.billilge.api.backend.domain.display.repository
+
+import site.billilge.api.backend.domain.display.entity.DisplayPoster
+
+interface DisplayPosterRepository {
+    fun findById(id: Long): DisplayPoster?
+    fun findAll(): List<DisplayPoster>
+    fun save(poster: DisplayPoster): DisplayPoster
+    fun delete(id: Long)
+    fun findByIsActiveTrue(): List<DisplayPoster>
+}

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/item/entity/Item.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/item/entity/Item.kt
@@ -1,0 +1,11 @@
+package site.billilge.api.backend.domain.item.entity
+
+import site.billilge.api.backend.domain.item.enums.ItemType
+
+data class Item(
+    val id: Long?,
+    val name: String,
+    val type: ItemType,
+    val count: Int,
+    val imageUrl: String,
+)

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/item/enums/ItemType.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/item/enums/ItemType.kt
@@ -1,0 +1,6 @@
+package site.billilge.api.backend.domain.item.enums
+
+enum class ItemType(val displayName: String) {
+    CONSUMPTION("소모품"),
+    RENTAL("대여품"),
+}

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/item/exception/ItemErrorCode.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/item/exception/ItemErrorCode.kt
@@ -1,0 +1,14 @@
+package site.billilge.api.backend.domain.item.exception
+
+import org.springframework.http.HttpStatus
+import site.billilge.api.backend.common.exception.ErrorCode
+
+enum class ItemErrorCode(
+    override val message: String,
+    override val httpStatus: HttpStatus,
+) : ErrorCode {
+    ITEM_ID_IS_NULL("물품의 ID를 가져올 수 없습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    ITEM_NAME_ALREADY_EXISTS("이미 존재하는 물품 이름입니다.", HttpStatus.BAD_REQUEST),
+    ITEM_NOT_FOUND("물품 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    IMAGE_IS_NOT_SVG("이미지 파일은 svg 확장자만 가능합니다.", HttpStatus.BAD_REQUEST),
+}

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/item/exception/ItemErrorCode.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/item/exception/ItemErrorCode.kt
@@ -1,14 +1,13 @@
 package site.billilge.api.backend.domain.item.exception
 
-import org.springframework.http.HttpStatus
 import site.billilge.api.backend.common.exception.ErrorCode
 
 enum class ItemErrorCode(
     override val message: String,
-    override val httpStatus: HttpStatus,
+    override val status: Int,
 ) : ErrorCode {
-    ITEM_ID_IS_NULL("물품의 ID를 가져올 수 없습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
-    ITEM_NAME_ALREADY_EXISTS("이미 존재하는 물품 이름입니다.", HttpStatus.BAD_REQUEST),
-    ITEM_NOT_FOUND("물품 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
-    IMAGE_IS_NOT_SVG("이미지 파일은 svg 확장자만 가능합니다.", HttpStatus.BAD_REQUEST),
+    ITEM_ID_IS_NULL("물품의 ID를 가져올 수 없습니다.", 500),
+    ITEM_NAME_ALREADY_EXISTS("이미 존재하는 물품 이름입니다.", 400),
+    ITEM_NOT_FOUND("물품 정보를 찾을 수 없습니다.", 404),
+    IMAGE_IS_NOT_SVG("이미지 파일은 svg 확장자만 가능합니다.", 400),
 }

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/item/repository/ItemRepository.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/item/repository/ItemRepository.kt
@@ -1,7 +1,7 @@
 package site.billilge.api.backend.domain.item.repository
 
-import org.springframework.data.domain.Page
-import org.springframework.data.domain.Pageable
+import site.billilge.api.backend.core.vo.PageRequest
+import site.billilge.api.backend.core.vo.PageResult
 import site.billilge.api.backend.domain.item.entity.Item
 import site.billilge.api.backend.domain.item.repository.dto.ItemWithRentCountQueryResult
 
@@ -12,5 +12,5 @@ interface ItemRepository {
     fun delete(id: Long)
     fun existsByName(name: String): Boolean
     fun findByItemName(search: String): List<Item>
-    fun findAllAsAdminItemDetailByKeyword(keyword: String, pageable: Pageable): Page<ItemWithRentCountQueryResult>
+    fun findAllAsAdminItemDetailByKeyword(keyword: String, pageRequest: PageRequest): PageResult<ItemWithRentCountQueryResult>
 }

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/item/repository/ItemRepository.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/item/repository/ItemRepository.kt
@@ -1,0 +1,16 @@
+package site.billilge.api.backend.domain.item.repository
+
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import site.billilge.api.backend.domain.item.entity.Item
+import site.billilge.api.backend.domain.item.repository.dto.ItemWithRentCountQueryResult
+
+interface ItemRepository {
+    fun findById(id: Long): Item?
+    fun findAll(): List<Item>
+    fun save(item: Item): Item
+    fun delete(id: Long)
+    fun existsByName(name: String): Boolean
+    fun findByItemName(search: String): List<Item>
+    fun findAllAsAdminItemDetailByKeyword(keyword: String, pageable: Pageable): Page<ItemWithRentCountQueryResult>
+}

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/item/repository/dto/ItemWithRentCountQueryResult.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/item/repository/dto/ItemWithRentCountQueryResult.kt
@@ -1,0 +1,12 @@
+package site.billilge.api.backend.domain.item.repository.dto
+
+import site.billilge.api.backend.domain.item.enums.ItemType
+
+data class ItemWithRentCountQueryResult(
+    val itemId: Long,
+    val itemName: String,
+    val itemType: ItemType,
+    val count: Int,
+    val renterCount: Long,
+    val imageUrl: String,
+)

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/member/entity/Member.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/member/entity/Member.kt
@@ -1,0 +1,18 @@
+package site.billilge.api.backend.domain.member.entity
+
+import site.billilge.api.backend.domain.member.enums.Department
+import site.billilge.api.backend.domain.member.enums.Role
+import java.time.LocalDateTime
+
+data class Member(
+    val id: Long?,
+    val name: String,
+    val studentId: String,
+    val isFeePaid: Boolean = false,
+    val email: String? = null,
+    val department: Department = Department.SW,
+    val role: Role = Role.USER,
+    val fcmToken: String? = null,
+    val createdAt: LocalDateTime = LocalDateTime.now(),
+    val updatedAt: LocalDateTime = LocalDateTime.now(),
+)

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/member/enums/Department.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/member/enums/Department.kt
@@ -1,0 +1,6 @@
+package site.billilge.api.backend.domain.member.enums
+
+enum class Department(val displayName: String) {
+    SW("소프트웨어학부"),
+    AI("인공지능학부"),
+}

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/member/enums/Role.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/member/enums/Role.kt
@@ -1,0 +1,11 @@
+package site.billilge.api.backend.domain.member.enums
+
+enum class Role(
+    val key: String,
+    val description: String,
+) {
+    USER("ROLE_USER", "사용자"),
+    ADMIN("ROLE_ADMIN", "관리자"),
+    WORKER("ROLE_WORKER", "근무자"),
+    GA("ROLE_GA", "총무부"),
+}

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/member/exception/MemberErrorCode.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/member/exception/MemberErrorCode.kt
@@ -1,0 +1,14 @@
+package site.billilge.api.backend.domain.member.exception
+
+import org.springframework.http.HttpStatus
+import site.billilge.api.backend.common.exception.ErrorCode
+
+enum class MemberErrorCode(
+    override val message: String,
+    override val httpStatus: HttpStatus,
+) : ErrorCode {
+    MEMBER_NOT_FOUND("존재하지 않는 회원입니다.", HttpStatus.BAD_REQUEST),
+    EMAIL_ALREADY_EXISTS("이미 존재하는 회원의 이메일입니다.", HttpStatus.BAD_REQUEST),
+    FORBIDDEN("접근 권한이 없습니다.", HttpStatus.FORBIDDEN),
+    ADMIN_PASSWORD_MISMATCH("비밀번호가 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
+}

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/member/exception/MemberErrorCode.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/member/exception/MemberErrorCode.kt
@@ -1,14 +1,13 @@
 package site.billilge.api.backend.domain.member.exception
 
-import org.springframework.http.HttpStatus
 import site.billilge.api.backend.common.exception.ErrorCode
 
 enum class MemberErrorCode(
     override val message: String,
-    override val httpStatus: HttpStatus,
+    override val status: Int,
 ) : ErrorCode {
-    MEMBER_NOT_FOUND("존재하지 않는 회원입니다.", HttpStatus.BAD_REQUEST),
-    EMAIL_ALREADY_EXISTS("이미 존재하는 회원의 이메일입니다.", HttpStatus.BAD_REQUEST),
-    FORBIDDEN("접근 권한이 없습니다.", HttpStatus.FORBIDDEN),
-    ADMIN_PASSWORD_MISMATCH("비밀번호가 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
+    MEMBER_NOT_FOUND("존재하지 않는 회원입니다.", 400),
+    EMAIL_ALREADY_EXISTS("이미 존재하는 회원의 이메일입니다.", 400),
+    FORBIDDEN("접근 권한이 없습니다.", 403),
+    ADMIN_PASSWORD_MISMATCH("비밀번호가 일치하지 않습니다.", 400),
 }

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/member/repository/MemberRepository.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/member/repository/MemberRepository.kt
@@ -1,7 +1,7 @@
 package site.billilge.api.backend.domain.member.repository
 
-import org.springframework.data.domain.Page
-import org.springframework.data.domain.Pageable
+import site.billilge.api.backend.core.vo.PageRequest
+import site.billilge.api.backend.core.vo.PageResult
 import site.billilge.api.backend.domain.member.entity.Member
 import site.billilge.api.backend.domain.member.enums.Role
 
@@ -12,9 +12,9 @@ interface MemberRepository {
     fun existsByEmail(email: String): Boolean
     fun existsByStudentIdAndName(studentId: String, name: String): Boolean
     fun save(member: Member): Member
-    fun findAllByRoleAndNameContaining(role: Role, name: String, pageable: Pageable): Page<Member>
-    fun findAllByRoleInAndNameContaining(roles: List<Role>, name: String, pageable: Pageable): Page<Member>
-    fun findAllByNameContaining(name: String, pageable: Pageable): Page<Member>
+    fun findAllByRoleAndNameContaining(role: Role, name: String, pageRequest: PageRequest): PageResult<Member>
+    fun findAllByRoleInAndNameContaining(roles: List<Role>, name: String, pageRequest: PageRequest): PageResult<Member>
+    fun findAllByNameContaining(name: String, pageRequest: PageRequest): PageResult<Member>
     fun findAllByIds(ids: List<Long>): List<Member>
     fun findAllByStudentIds(studentIds: List<String>): List<Member>
     fun findAllByRole(role: Role): List<Member>

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/member/repository/MemberRepository.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/member/repository/MemberRepository.kt
@@ -1,0 +1,23 @@
+package site.billilge.api.backend.domain.member.repository
+
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import site.billilge.api.backend.domain.member.entity.Member
+import site.billilge.api.backend.domain.member.enums.Role
+
+interface MemberRepository {
+    fun findById(id: Long): Member?
+    fun findByEmail(email: String): Member?
+    fun findByStudentId(studentId: String): Member?
+    fun existsByEmail(email: String): Boolean
+    fun existsByStudentIdAndName(studentId: String, name: String): Boolean
+    fun save(member: Member): Member
+    fun findAllByRoleAndNameContaining(role: Role, name: String, pageable: Pageable): Page<Member>
+    fun findAllByRoleInAndNameContaining(roles: List<Role>, name: String, pageable: Pageable): Page<Member>
+    fun findAllByNameContaining(name: String, pageable: Pageable): Page<Member>
+    fun findAllByIds(ids: List<Long>): List<Member>
+    fun findAllByStudentIds(studentIds: List<String>): List<Member>
+    fun findAllByRole(role: Role): List<Member>
+    fun findByStudentIdAndName(studentId: String, name: String): Member?
+    fun findAllByRoleIn(roles: Set<Role>): List<Member>
+}

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/notification/entity/Notification.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/notification/entity/Notification.kt
@@ -1,0 +1,17 @@
+package site.billilge.api.backend.domain.notification.entity
+
+import site.billilge.api.backend.domain.member.entity.Member
+import site.billilge.api.backend.domain.notification.enums.NotificationStatus
+import java.time.LocalDateTime
+
+data class Notification(
+    val id: Long?,
+    val member: Member?,
+    val status: NotificationStatus,
+    val formatValues: String? = null,
+    val isRead: Boolean = false,
+    val createdAt: LocalDateTime = LocalDateTime.now(),
+) {
+    val formatValueList: List<String>
+        get() = formatValues?.split(",") ?: emptyList()
+}

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/notification/enums/NotificationStatus.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/notification/enums/NotificationStatus.kt
@@ -1,0 +1,60 @@
+package site.billilge.api.backend.domain.notification.enums
+
+enum class NotificationStatus(
+    val title: String,
+    val message: String,
+    val link: String,
+) {
+    ADMIN_RENTAL_APPLY(
+        "대여 신청",
+        "%s(%s) 님이 %s에 %s 대여를 신청했어요.",
+        "/mobile/admin/dashboard"
+    ),
+    ADMIN_RENTAL_CANCEL(
+        "신청 취소",
+        "%s(%s) 님이 %s 대여 신청을 취소했어요.",
+        "/mobile/admin/dashboard"
+    ),
+    ADMIN_RETURN_APPLY(
+        "반납 신청",
+        "%s(%s) 님이 %s 반납을 신청했어요.",
+        "/mobile/admin/dashboard"
+    ),
+    ADMIN_RETURN_CANCEL(
+        "반납 취소",
+        "%s(%s) 님이 %s 반납 신청을 취소했어요.",
+        "/mobile/admin/dashboard"
+    ),
+    USER_RENTAL_APPLY(
+        "대여 신청",
+        "%s 대여를 신청했어요!\n관리자가 처리할 때까지 잠시만 기다려 주세요.",
+        "/mobile/history"
+    ),
+    USER_RENTAL_APPROVED(
+        "대여 승인",
+        "관리자가 %s 대여 신청을 승인했어요!\n대여 시각에 과방으로 오시면 물품을 빌릴 수 있어요.",
+        "/mobile/history"
+    ),
+    USER_RENTAL_REJECTED(
+        "대여 반려",
+        "%s 대여 신청이 반려되었어요.\n자세한 사항은 소프트웨어융합대학 카카오톡에 문의해 주세요.",
+        "/mobile/history"
+    ),
+    USER_RETURN_APPLY(
+        "반납 신청",
+        "%s 반납을 신청했어요!\n관리자가 처리할 때까지 잠시만 기다려 주세요.",
+        "/mobile/history"
+    ),
+    USER_RETURN_APPROVED(
+        "반납 승인",
+        "관리자가 %s 반납 신청을 승인했어요!\n과방으로 오시면 물품을 반납할 수 있어요.",
+        "/mobile/history"
+    ),
+    USER_RETURN_COMPLETED(
+        "반납 완료",
+        "%s 반납을 완료했어요.",
+        "/mobile/history"
+    );
+
+    fun formattedMessage(vararg formatValues: String): String = message.format(*formatValues)
+}

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/notification/exception/NotificationErrorCode.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/notification/exception/NotificationErrorCode.kt
@@ -1,12 +1,11 @@
 package site.billilge.api.backend.domain.notification.exception
 
-import org.springframework.http.HttpStatus
 import site.billilge.api.backend.common.exception.ErrorCode
 
 enum class NotificationErrorCode(
     override val message: String,
-    override val httpStatus: HttpStatus,
+    override val status: Int,
 ) : ErrorCode {
-    NOTIFICATION_NOT_FOUND("알림 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
-    NOTIFICATION_ACCESS_DENIED("알림을 수정할 권한이 없습니다.", HttpStatus.FORBIDDEN),
+    NOTIFICATION_NOT_FOUND("알림 정보를 찾을 수 없습니다.", 404),
+    NOTIFICATION_ACCESS_DENIED("알림을 수정할 권한이 없습니다.", 403),
 }

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/notification/exception/NotificationErrorCode.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/notification/exception/NotificationErrorCode.kt
@@ -1,0 +1,12 @@
+package site.billilge.api.backend.domain.notification.exception
+
+import org.springframework.http.HttpStatus
+import site.billilge.api.backend.common.exception.ErrorCode
+
+enum class NotificationErrorCode(
+    override val message: String,
+    override val httpStatus: HttpStatus,
+) : ErrorCode {
+    NOTIFICATION_NOT_FOUND("알림 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    NOTIFICATION_ACCESS_DENIED("알림을 수정할 권한이 없습니다.", HttpStatus.FORBIDDEN),
+}

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/notification/repository/NotificationRepository.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/notification/repository/NotificationRepository.kt
@@ -1,0 +1,12 @@
+package site.billilge.api.backend.domain.notification.repository
+
+import site.billilge.api.backend.domain.notification.entity.Notification
+
+interface NotificationRepository {
+    fun findById(id: Long): Notification?
+    fun save(notification: Notification): Notification
+    fun saveAll(notifications: List<Notification>): List<Notification>
+    fun findAllUserNotificationsByMemberId(memberId: Long): List<Notification>
+    fun findAllAdminNotificationsByMemberId(memberId: Long): List<Notification>
+    fun countUserNotificationsByMemberId(memberId: Long): Int
+}

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/payer/entity/Payer.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/payer/entity/Payer.kt
@@ -1,0 +1,9 @@
+package site.billilge.api.backend.domain.payer.entity
+
+data class Payer(
+    val id: Long?,
+    val name: String,
+    val enrollmentYear: String,
+    val studentId: String? = null,
+    val registered: Boolean = false,
+)

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/payer/repository/PayerRepository.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/payer/repository/PayerRepository.kt
@@ -1,0 +1,18 @@
+package site.billilge.api.backend.domain.payer.repository
+
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import site.billilge.api.backend.domain.payer.entity.Payer
+
+interface PayerRepository {
+    fun findById(id: Long): Payer?
+    fun findAll(): List<Payer>
+    fun save(payer: Payer): Payer
+    fun saveAll(payers: List<Payer>): List<Payer>
+    fun delete(id: Long)
+    fun deleteAll(ids: List<Long>)
+    fun findAllByNameAndEnrollmentYear(name: String, enrollmentYear: String): List<Payer>
+    fun findAllByIds(ids: List<Long>): List<Payer>
+    fun findAllByNameContaining(name: String, pageable: Pageable): Page<Payer>
+    fun findAllByEnrollmentYear(enrollmentYear: String): List<Payer>
+}

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/payer/repository/PayerRepository.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/payer/repository/PayerRepository.kt
@@ -1,7 +1,7 @@
 package site.billilge.api.backend.domain.payer.repository
 
-import org.springframework.data.domain.Page
-import org.springframework.data.domain.Pageable
+import site.billilge.api.backend.core.vo.PageRequest
+import site.billilge.api.backend.core.vo.PageResult
 import site.billilge.api.backend.domain.payer.entity.Payer
 
 interface PayerRepository {
@@ -13,6 +13,6 @@ interface PayerRepository {
     fun deleteAll(ids: List<Long>)
     fun findAllByNameAndEnrollmentYear(name: String, enrollmentYear: String): List<Payer>
     fun findAllByIds(ids: List<Long>): List<Payer>
-    fun findAllByNameContaining(name: String, pageable: Pageable): Page<Payer>
+    fun findAllByNameContaining(name: String, pageRequest: PageRequest): PageResult<Payer>
     fun findAllByEnrollmentYear(enrollmentYear: String): List<Payer>
 }

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/rental/entity/RentalHistory.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/rental/entity/RentalHistory.kt
@@ -1,0 +1,19 @@
+package site.billilge.api.backend.domain.rental.entity
+
+import site.billilge.api.backend.domain.item.entity.Item
+import site.billilge.api.backend.domain.member.entity.Member
+import site.billilge.api.backend.domain.rental.enums.RentalStatus
+import java.time.LocalDateTime
+
+data class RentalHistory(
+    val id: Long?,
+    val member: Member,
+    val item: Item,
+    val rentalStatus: RentalStatus,
+    val rentAt: LocalDateTime,
+    val returnedAt: LocalDateTime? = null,
+    val rentedCount: Int,
+    val itemCode: String? = null,
+    val worker: Member? = null,
+    val applicatedAt: LocalDateTime = LocalDateTime.now(),
+)

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/rental/entity/RentalStatusWorkerLog.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/rental/entity/RentalStatusWorkerLog.kt
@@ -1,0 +1,13 @@
+package site.billilge.api.backend.domain.rental.entity
+
+import site.billilge.api.backend.domain.member.entity.Member
+import site.billilge.api.backend.domain.rental.enums.RentalStatus
+import java.time.LocalDateTime
+
+data class RentalStatusWorkerLog(
+    val id: Long?,
+    val rentalHistoryId: Long,
+    val rentalStatus: RentalStatus,
+    val worker: Member? = null,
+    val createdAt: LocalDateTime = LocalDateTime.now(),
+)

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/rental/enums/RentalStatus.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/rental/enums/RentalStatus.kt
@@ -1,0 +1,12 @@
+package site.billilge.api.backend.domain.rental.enums
+
+enum class RentalStatus(val displayName: String) {
+    PENDING("승인 대기 중"),
+    CANCEL("대기 취소"),
+    CONFIRMED("승인 완료"),
+    REJECTED("대여 반려"),
+    RENTAL("대여 중"),
+    RETURN_PENDING("반납 대기 중"),
+    RETURN_CONFIRMED("반납 승인"),
+    RETURNED("반납 완료"),
+}

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/rental/event/RentalEvents.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/rental/event/RentalEvents.kt
@@ -1,0 +1,27 @@
+package site.billilge.api.backend.domain.rental.event
+
+import site.billilge.api.backend.domain.rental.enums.RentalStatus
+import java.time.LocalDateTime
+
+data class RentalAppliedEvent(
+    val memberId: Long,
+    val itemName: String,
+    val rentAt: LocalDateTime,
+    val isDevMode: Boolean,
+)
+
+data class RentalCancelledEvent(
+    val memberId: Long,
+    val itemName: String,
+)
+
+data class ReturnAppliedEvent(
+    val memberId: Long,
+    val itemName: String,
+)
+
+data class RentalStatusChangedEvent(
+    val memberId: Long,
+    val itemName: String,
+    val status: RentalStatus,
+)

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/rental/exception/RentalErrorCode.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/rental/exception/RentalErrorCode.kt
@@ -1,21 +1,20 @@
 package site.billilge.api.backend.domain.rental.exception
 
-import org.springframework.http.HttpStatus
 import site.billilge.api.backend.common.exception.ErrorCode
 
 enum class RentalErrorCode(
     override val message: String,
-    override val httpStatus: HttpStatus,
+    override val status: Int,
 ) : ErrorCode {
-    ITEM_NOT_FOUND("물품 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
-    MEMBER_NOT_FOUND("사용자 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
-    ITEM_OUT_OF_STOCK("물품의 재고가 부족합니다.", HttpStatus.BAD_REQUEST),
-    RENTAL_ITEM_DUPLICATED("이미 대여 중인 물품입니다.\n중복 대여하시겠습니까?", HttpStatus.CONFLICT),
-    INVALID_RENTAL_TIME_OUT_OF_RANGE("대여 가능시간은 10:00 ~ 17:00입니다. 다시 입력해주세요", HttpStatus.BAD_REQUEST),
-    INVALID_RENTAL_TIME_PAST("현재 시간보다 이후의 시간으로 설정해주세요", HttpStatus.BAD_REQUEST),
-    INVALID_RENTAL_TIME_WEEKEND("주말에는 대여가 불가능합니다.", HttpStatus.BAD_REQUEST),
-    RENTAL_NOT_FOUND("대여 기록을 찾을 수 없습니다", HttpStatus.NOT_FOUND),
-    MEMBER_IS_NOT_PAYER("복지물품을 대여하려면 먼저 학생회비를 납부해주세요.", HttpStatus.FORBIDDEN),
-    MEMBER_IS_NOT_PAYER_ADMIN("학생회비를 납부하지 않은 회원입니다.", HttpStatus.FORBIDDEN),
-    TODAY_IS_IN_EXAM_PERIOD("시험기간에는\n대여가 불가능합니다.\n양해 부탁드립니다.", HttpStatus.BAD_REQUEST),
+    ITEM_NOT_FOUND("물품 정보를 찾을 수 없습니다.", 404),
+    MEMBER_NOT_FOUND("사용자 정보를 찾을 수 없습니다.", 404),
+    ITEM_OUT_OF_STOCK("물품의 재고가 부족합니다.", 400),
+    RENTAL_ITEM_DUPLICATED("이미 대여 중인 물품입니다.\n중복 대여하시겠습니까?", 409),
+    INVALID_RENTAL_TIME_OUT_OF_RANGE("대여 가능시간은 10:00 ~ 17:00입니다. 다시 입력해주세요", 400),
+    INVALID_RENTAL_TIME_PAST("현재 시간보다 이후의 시간으로 설정해주세요", 400),
+    INVALID_RENTAL_TIME_WEEKEND("주말에는 대여가 불가능합니다.", 400),
+    RENTAL_NOT_FOUND("대여 기록을 찾을 수 없습니다", 404),
+    MEMBER_IS_NOT_PAYER("복지물품을 대여하려면 먼저 학생회비를 납부해주세요.", 403),
+    MEMBER_IS_NOT_PAYER_ADMIN("학생회비를 납부하지 않은 회원입니다.", 403),
+    TODAY_IS_IN_EXAM_PERIOD("시험기간에는\n대여가 불가능합니다.\n양해 부탁드립니다.", 400),
 }

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/rental/exception/RentalErrorCode.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/rental/exception/RentalErrorCode.kt
@@ -1,0 +1,21 @@
+package site.billilge.api.backend.domain.rental.exception
+
+import org.springframework.http.HttpStatus
+import site.billilge.api.backend.common.exception.ErrorCode
+
+enum class RentalErrorCode(
+    override val message: String,
+    override val httpStatus: HttpStatus,
+) : ErrorCode {
+    ITEM_NOT_FOUND("물품 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    MEMBER_NOT_FOUND("사용자 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    ITEM_OUT_OF_STOCK("물품의 재고가 부족합니다.", HttpStatus.BAD_REQUEST),
+    RENTAL_ITEM_DUPLICATED("이미 대여 중인 물품입니다.\n중복 대여하시겠습니까?", HttpStatus.CONFLICT),
+    INVALID_RENTAL_TIME_OUT_OF_RANGE("대여 가능시간은 10:00 ~ 17:00입니다. 다시 입력해주세요", HttpStatus.BAD_REQUEST),
+    INVALID_RENTAL_TIME_PAST("현재 시간보다 이후의 시간으로 설정해주세요", HttpStatus.BAD_REQUEST),
+    INVALID_RENTAL_TIME_WEEKEND("주말에는 대여가 불가능합니다.", HttpStatus.BAD_REQUEST),
+    RENTAL_NOT_FOUND("대여 기록을 찾을 수 없습니다", HttpStatus.NOT_FOUND),
+    MEMBER_IS_NOT_PAYER("복지물품을 대여하려면 먼저 학생회비를 납부해주세요.", HttpStatus.FORBIDDEN),
+    MEMBER_IS_NOT_PAYER_ADMIN("학생회비를 납부하지 않은 회원입니다.", HttpStatus.FORBIDDEN),
+    TODAY_IS_IN_EXAM_PERIOD("시험기간에는\n대여가 불가능합니다.\n양해 부탁드립니다.", HttpStatus.BAD_REQUEST),
+}

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/rental/repository/RentalRepository.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/rental/repository/RentalRepository.kt
@@ -1,7 +1,7 @@
 package site.billilge.api.backend.domain.rental.repository
 
-import org.springframework.data.domain.Page
-import org.springframework.data.domain.Pageable
+import site.billilge.api.backend.core.vo.PageRequest
+import site.billilge.api.backend.core.vo.PageResult
 import site.billilge.api.backend.domain.rental.entity.RentalHistory
 import site.billilge.api.backend.domain.rental.enums.RentalStatus
 
@@ -21,5 +21,5 @@ interface RentalRepository {
         rentalStatuses: Collection<RentalStatus>,
     ): List<RentalHistory>
     fun findAllByRentalStatusIn(rentalStatuses: List<RentalStatus>): List<RentalHistory>
-    fun findAllByMemberNameContaining(memberName: String, pageable: Pageable): Page<RentalHistory>
+    fun findAllByMemberNameContaining(memberName: String, pageRequest: PageRequest): PageResult<RentalHistory>
 }

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/rental/repository/RentalRepository.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/rental/repository/RentalRepository.kt
@@ -1,0 +1,25 @@
+package site.billilge.api.backend.domain.rental.repository
+
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import site.billilge.api.backend.domain.rental.entity.RentalHistory
+import site.billilge.api.backend.domain.rental.enums.RentalStatus
+
+interface RentalRepository {
+    fun findById(id: Long): RentalHistory?
+    fun save(rentalHistory: RentalHistory): RentalHistory
+    fun delete(id: Long)
+    fun findByMemberId(memberId: Long): List<RentalHistory>
+    fun findByItemIdAndMemberIdAndRentalStatus(
+        itemId: Long,
+        memberId: Long,
+        rentalStatus: RentalStatus,
+    ): RentalHistory?
+    fun findByMemberIdAndRentalStatus(memberId: Long, rentalStatus: RentalStatus): List<RentalHistory>
+    fun findByMemberIdAndRentalStatusIn(
+        memberId: Long,
+        rentalStatuses: Collection<RentalStatus>,
+    ): List<RentalHistory>
+    fun findAllByRentalStatusIn(rentalStatuses: List<RentalStatus>): List<RentalHistory>
+    fun findAllByMemberNameContaining(memberName: String, pageable: Pageable): Page<RentalHistory>
+}

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/rental/repository/RentalStatusWorkerLogRepository.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/rental/repository/RentalStatusWorkerLogRepository.kt
@@ -1,0 +1,8 @@
+package site.billilge.api.backend.domain.rental.repository
+
+import site.billilge.api.backend.domain.rental.entity.RentalStatusWorkerLog
+
+interface RentalStatusWorkerLogRepository {
+    fun save(log: RentalStatusWorkerLog): RentalStatusWorkerLog
+    fun findAllByRentalHistoryIdOrderByCreatedAtAsc(rentalHistoryId: Long): List<RentalStatusWorkerLog>
+}

--- a/core/src/main/resources/core.yml
+++ b/core/src/main/resources/core.yml
@@ -1,0 +1,3 @@
+exam-period:
+  start-date: "2025-01-01"
+  end-date: "2025-01-15"


### PR DESCRIPTION
## 개요

Phase 3: core 모듈의 컨트랙트 레이어(인터페이스 + 순수 도메인 타입)를 구성합니다.

## 변경 사항

### Port 인터페이스 (`core/port/`)
- `FCMPort` — FCM 푸시 알림 발송 추상화
- `ExcelGeneratorPort` — 엑셀 생성 추상화
- `FileStorageService` — 파일 업로드/삭제 추상화
  - `MultipartFile` 대신 `FileUploadRequest(ByteArray)` 사용 → core가 spring-web에 직접 의존하지 않도록

### 순수 도메인 data class (`domain/{name}/entity/`)
- 7개 도메인: Item, Member, Notification, Payer, RentalHistory, RentalStatusWorkerLog, ConfigValue, DisplayCalendarSchedule, DisplayPoster
- JPA 어노테이션 없음, 비즈니스 메서드 없음 — 순수 Kotlin data class

### Repository 인터페이스 (`domain/{name}/repository/`)
- 9개 도메인 Repository 인터페이스 정의
- JpaRepository 미사용 — 도메인 객체를 직접 반환
- 페이지네이션: Spring `Page`/`Pageable` → core 자체 VO `PageRequest`/`PageResult<T>`

### 도메인 자체 VO (`core/vo/`)
- `PageRequest` — 페이지 번호/크기/정렬 조건
- `PageResult<T>` — 페이지 결과 (content, totalElements, totalPages 등)

### Enum (`domain/{name}/enums/`)
- ItemType, Department, Role, NotificationStatus, RentalStatus, ConfigValueKeys

### ErrorCode (`domain/{name}/exception/`)
- 7개 도메인 ErrorCode enum (common의 `ErrorCode` 인터페이스 구현)

### 기타
- `RentalEvents` 이동 (도메인 이벤트 data class)
- `ExamPeriodProperties` (`@ConfigurationProperties`) + `core.yml` 추가
- `ItemWithRentCountQueryResult` query DTO — core에 위치 (infra QueryDSL 구현이 이 타입 반환)

### Gradle 변경
- `common/build.gradle.kts`: `spring-boot-starter-web`을 `api` scope으로 변경 → `HttpStatus` 전이 노출
- `core/build.gradle.kts`: `kapt` 플러그인 + `spring-boot-configuration-processor` 추가

## 검증

```
./gradlew :core:compileKotlin  ✅
```

## 관련 이슈

Phase 3 of #126