### PR TITLE
refactor: core 모듈 비즈니스 레이어 구성 (Phase 4)

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -7,7 +7,9 @@ dependencies {
     implementation(project(":common"))
 
     implementation("org.springframework.boot:spring-boot-starter")
+    implementation("org.springframework:spring-tx")
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
+    implementation("io.github.oshai:kotlin-logging-jvm:7.0.3")
     kapt("org.springframework.boot:spring-boot-configuration-processor")
 }

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/configvalue/appender/ConfigValueAppender.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/configvalue/appender/ConfigValueAppender.kt
@@ -1,0 +1,11 @@
+package site.billilge.api.backend.domain.configvalue.appender
+
+import org.springframework.stereotype.Component
+import site.billilge.api.backend.domain.configvalue.entity.ConfigValue
+import site.billilge.api.backend.domain.configvalue.repository.ConfigValueRepository
+
+@Component
+class ConfigValueAppender(private val configValueRepository: ConfigValueRepository) {
+
+    fun save(configValue: ConfigValue): ConfigValue = configValueRepository.save(configValue)
+}

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/configvalue/reader/ConfigValueReader.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/configvalue/reader/ConfigValueReader.kt
@@ -1,0 +1,17 @@
+package site.billilge.api.backend.domain.configvalue.reader
+
+import org.springframework.stereotype.Component
+import site.billilge.api.backend.common.exception.ApiException
+import site.billilge.api.backend.domain.configvalue.entity.ConfigValue
+import site.billilge.api.backend.domain.configvalue.exception.ConfigValueErrorCode
+import site.billilge.api.backend.domain.configvalue.repository.ConfigValueRepository
+
+@Component
+class ConfigValueReader(private val configValueRepository: ConfigValueRepository) {
+
+    fun read(key: String): ConfigValue =
+        configValueRepository.findByKey(key) ?: throw ApiException(ConfigValueErrorCode.CONFIG_VALUE_NOT_FOUND)
+
+    fun readAllByKeys(keys: List<String>): List<ConfigValue> =
+        configValueRepository.findAllByKeyIn(keys)
+}

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/configvalue/service/ConfigValueService.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/configvalue/service/ConfigValueService.kt
@@ -1,0 +1,40 @@
+package site.billilge.api.backend.domain.configvalue.service
+
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import site.billilge.api.backend.common.exception.ApiException
+import site.billilge.api.backend.domain.configvalue.appender.ConfigValueAppender
+import site.billilge.api.backend.domain.configvalue.entity.ConfigValue
+import site.billilge.api.backend.domain.configvalue.exception.ConfigValueErrorCode
+import site.billilge.api.backend.domain.configvalue.reader.ConfigValueReader
+
+@Service
+@Transactional(readOnly = true)
+class ConfigValueService(
+    private val configValueReader: ConfigValueReader,
+    private val configValueAppender: ConfigValueAppender,
+) {
+    fun getByKey(key: String): ConfigValue = configValueReader.read(key)
+
+    fun getValueByKey(key: String): String = configValueReader.read(key).value
+
+    fun getMapByKeys(keys: List<String>): Map<String, String> =
+        configValueReader.readAllByKeys(keys).associate { it.key to it.value }
+
+    @Transactional
+    fun upsert(key: String, value: String) {
+        val existing = configValueReader.readAllByKeys(listOf(key)).firstOrNull()
+        if (existing != null) {
+            configValueAppender.save(existing.copy(value = value))
+        } else {
+            configValueAppender.save(ConfigValue(id = null, key = key, value = value))
+        }
+    }
+
+    @Transactional
+    fun changeAdminPassword(currentPassword: String, newPassword: String) {
+        val configValue = configValueReader.read(site.billilge.api.backend.domain.configvalue.enums.ConfigValueKeys.ADMIN_PASSWORD.key)
+        if (configValue.value != currentPassword) throw ApiException(ConfigValueErrorCode.ADMIN_PASSWORD_MISMATCH)
+        configValueAppender.save(configValue.copy(value = newPassword))
+    }
+}

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/display/appender/DisplayCalendarScheduleAppender.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/display/appender/DisplayCalendarScheduleAppender.kt
@@ -1,0 +1,12 @@
+package site.billilge.api.backend.domain.display.appender
+
+import org.springframework.stereotype.Component
+import site.billilge.api.backend.domain.display.entity.DisplayCalendarSchedule
+import site.billilge.api.backend.domain.display.repository.DisplayCalendarScheduleRepository
+
+@Component
+class DisplayCalendarScheduleAppender(private val displayCalendarScheduleRepository: DisplayCalendarScheduleRepository) {
+
+    fun save(schedule: DisplayCalendarSchedule): DisplayCalendarSchedule =
+        displayCalendarScheduleRepository.save(schedule)
+}

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/display/appender/DisplayPosterAppender.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/display/appender/DisplayPosterAppender.kt
@@ -1,0 +1,11 @@
+package site.billilge.api.backend.domain.display.appender
+
+import org.springframework.stereotype.Component
+import site.billilge.api.backend.domain.display.entity.DisplayPoster
+import site.billilge.api.backend.domain.display.repository.DisplayPosterRepository
+
+@Component
+class DisplayPosterAppender(private val displayPosterRepository: DisplayPosterRepository) {
+
+    fun save(poster: DisplayPoster): DisplayPoster = displayPosterRepository.save(poster)
+}

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/display/reader/DisplayCalendarScheduleReader.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/display/reader/DisplayCalendarScheduleReader.kt
@@ -1,0 +1,19 @@
+package site.billilge.api.backend.domain.display.reader
+
+import org.springframework.stereotype.Component
+import site.billilge.api.backend.common.exception.ApiException
+import site.billilge.api.backend.domain.display.entity.DisplayCalendarSchedule
+import site.billilge.api.backend.domain.display.exception.DisplayCalendarScheduleErrorCode
+import site.billilge.api.backend.domain.display.repository.DisplayCalendarScheduleRepository
+import java.time.LocalDate
+
+@Component
+class DisplayCalendarScheduleReader(private val displayCalendarScheduleRepository: DisplayCalendarScheduleRepository) {
+
+    fun read(id: Long): DisplayCalendarSchedule =
+        displayCalendarScheduleRepository.findById(id)
+            ?: throw ApiException(DisplayCalendarScheduleErrorCode.SCHEDULE_NOT_FOUND)
+
+    fun readByDateBetween(startDate: LocalDate, endDate: LocalDate): List<DisplayCalendarSchedule> =
+        displayCalendarScheduleRepository.findByDateBetween(startDate, endDate)
+}

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/display/reader/DisplayPosterReader.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/display/reader/DisplayPosterReader.kt
@@ -1,0 +1,18 @@
+package site.billilge.api.backend.domain.display.reader
+
+import org.springframework.stereotype.Component
+import site.billilge.api.backend.common.exception.ApiException
+import site.billilge.api.backend.domain.display.entity.DisplayPoster
+import site.billilge.api.backend.domain.display.exception.DisplayPosterErrorCode
+import site.billilge.api.backend.domain.display.repository.DisplayPosterRepository
+
+@Component
+class DisplayPosterReader(private val displayPosterRepository: DisplayPosterRepository) {
+
+    fun read(id: Long): DisplayPoster =
+        displayPosterRepository.findById(id) ?: throw ApiException(DisplayPosterErrorCode.POSTER_NOT_FOUND)
+
+    fun readAll(): List<DisplayPoster> = displayPosterRepository.findAll()
+
+    fun readAllActive(): List<DisplayPoster> = displayPosterRepository.findByIsActiveTrue()
+}

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/display/remover/DisplayCalendarScheduleRemover.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/display/remover/DisplayCalendarScheduleRemover.kt
@@ -1,0 +1,10 @@
+package site.billilge.api.backend.domain.display.remover
+
+import org.springframework.stereotype.Component
+import site.billilge.api.backend.domain.display.repository.DisplayCalendarScheduleRepository
+
+@Component
+class DisplayCalendarScheduleRemover(private val displayCalendarScheduleRepository: DisplayCalendarScheduleRepository) {
+
+    fun remove(id: Long) = displayCalendarScheduleRepository.delete(id)
+}

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/display/remover/DisplayPosterRemover.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/display/remover/DisplayPosterRemover.kt
@@ -1,0 +1,10 @@
+package site.billilge.api.backend.domain.display.remover
+
+import org.springframework.stereotype.Component
+import site.billilge.api.backend.domain.display.repository.DisplayPosterRepository
+
+@Component
+class DisplayPosterRemover(private val displayPosterRepository: DisplayPosterRepository) {
+
+    fun remove(id: Long) = displayPosterRepository.delete(id)
+}

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/display/service/DisplayCalendarScheduleService.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/display/service/DisplayCalendarScheduleService.kt
@@ -1,0 +1,41 @@
+package site.billilge.api.backend.domain.display.service
+
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import site.billilge.api.backend.domain.display.appender.DisplayCalendarScheduleAppender
+import site.billilge.api.backend.domain.display.entity.DisplayCalendarSchedule
+import site.billilge.api.backend.domain.display.reader.DisplayCalendarScheduleReader
+import site.billilge.api.backend.domain.display.remover.DisplayCalendarScheduleRemover
+import java.time.LocalDate
+
+@Service
+@Transactional(readOnly = true)
+class DisplayCalendarScheduleService(
+    private val displayCalendarScheduleReader: DisplayCalendarScheduleReader,
+    private val displayCalendarScheduleAppender: DisplayCalendarScheduleAppender,
+    private val displayCalendarScheduleRemover: DisplayCalendarScheduleRemover,
+) {
+    fun getSchedules(startDate: LocalDate, endDate: LocalDate): List<DisplayCalendarSchedule> =
+        displayCalendarScheduleReader.readByDateBetween(startDate, endDate)
+
+    @Transactional
+    fun addSchedule(date: LocalDate, schedules: List<String>) {
+        displayCalendarScheduleAppender.save(
+            DisplayCalendarSchedule(id = null, date = date, schedules = schedules.joinToString("|"))
+        )
+    }
+
+    @Transactional
+    fun updateSchedule(scheduleId: Long, date: LocalDate, schedules: List<String>) {
+        val schedule = displayCalendarScheduleReader.read(scheduleId)
+        displayCalendarScheduleAppender.save(
+            schedule.copy(date = date, schedules = schedules.joinToString("|"))
+        )
+    }
+
+    @Transactional
+    fun deleteSchedule(scheduleId: Long) {
+        displayCalendarScheduleReader.read(scheduleId)
+        displayCalendarScheduleRemover.remove(scheduleId)
+    }
+}

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/display/service/DisplayPosterService.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/display/service/DisplayPosterService.kt
@@ -1,0 +1,49 @@
+package site.billilge.api.backend.domain.display.service
+
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import site.billilge.api.backend.domain.display.appender.DisplayPosterAppender
+import site.billilge.api.backend.domain.display.entity.DisplayPoster
+import site.billilge.api.backend.domain.display.reader.DisplayPosterReader
+import site.billilge.api.backend.domain.display.remover.DisplayPosterRemover
+
+@Service
+@Transactional(readOnly = true)
+class DisplayPosterService(
+    private val displayPosterReader: DisplayPosterReader,
+    private val displayPosterAppender: DisplayPosterAppender,
+    private val displayPosterRemover: DisplayPosterRemover,
+) {
+    fun getAllPosters(): List<DisplayPoster> = displayPosterReader.readAll()
+
+    fun getActivePosters(): List<DisplayPoster> = displayPosterReader.readAllActive()
+
+    @Transactional
+    fun addPoster(imageUrl: String, title: String) {
+        displayPosterAppender.save(DisplayPoster(id = null, title = title, imageUrl = imageUrl))
+    }
+
+    @Transactional
+    fun updatePoster(posterId: Long, imageUrl: String?, title: String) {
+        val poster = displayPosterReader.read(posterId)
+        displayPosterAppender.save(poster.copy(title = title, imageUrl = imageUrl ?: poster.imageUrl))
+    }
+
+    @Transactional
+    fun deletePoster(posterId: Long) {
+        displayPosterReader.read(posterId)
+        displayPosterRemover.remove(posterId)
+    }
+
+    @Transactional
+    fun activatePoster(posterId: Long) {
+        val poster = displayPosterReader.read(posterId)
+        displayPosterAppender.save(poster.copy(isActive = true))
+    }
+
+    @Transactional
+    fun deactivatePoster(posterId: Long) {
+        val poster = displayPosterReader.read(posterId)
+        displayPosterAppender.save(poster.copy(isActive = false))
+    }
+}

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/item/appender/ItemAppender.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/item/appender/ItemAppender.kt
@@ -1,0 +1,11 @@
+package site.billilge.api.backend.domain.item.appender
+
+import org.springframework.stereotype.Component
+import site.billilge.api.backend.domain.item.entity.Item
+import site.billilge.api.backend.domain.item.repository.ItemRepository
+
+@Component
+class ItemAppender(private val itemRepository: ItemRepository) {
+
+    fun save(item: Item): Item = itemRepository.save(item)
+}

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/item/reader/ItemReader.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/item/reader/ItemReader.kt
@@ -1,0 +1,26 @@
+package site.billilge.api.backend.domain.item.reader
+
+import org.springframework.stereotype.Component
+import site.billilge.api.backend.common.exception.ApiException
+import site.billilge.api.backend.core.vo.PageRequest
+import site.billilge.api.backend.core.vo.PageResult
+import site.billilge.api.backend.domain.item.entity.Item
+import site.billilge.api.backend.domain.item.exception.ItemErrorCode
+import site.billilge.api.backend.domain.item.repository.ItemRepository
+import site.billilge.api.backend.domain.item.repository.dto.ItemWithRentCountQueryResult
+
+@Component
+class ItemReader(private val itemRepository: ItemRepository) {
+
+    fun read(id: Long): Item =
+        itemRepository.findById(id) ?: throw ApiException(ItemErrorCode.ITEM_NOT_FOUND)
+
+    fun readAll(): List<Item> = itemRepository.findAll()
+
+    fun readByItemName(search: String): List<Item> = itemRepository.findByItemName(search)
+
+    fun readAllAsAdminDetail(keyword: String, pageRequest: PageRequest): PageResult<ItemWithRentCountQueryResult> =
+        itemRepository.findAllAsAdminItemDetailByKeyword(keyword, pageRequest)
+
+    fun existsByName(name: String): Boolean = itemRepository.existsByName(name)
+}

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/item/remover/ItemRemover.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/item/remover/ItemRemover.kt
@@ -1,0 +1,10 @@
+package site.billilge.api.backend.domain.item.remover
+
+import org.springframework.stereotype.Component
+import site.billilge.api.backend.domain.item.repository.ItemRepository
+
+@Component
+class ItemRemover(private val itemRepository: ItemRepository) {
+
+    fun remove(id: Long) = itemRepository.delete(id)
+}

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/item/service/ItemService.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/item/service/ItemService.kt
@@ -1,0 +1,100 @@
+package site.billilge.api.backend.domain.item.service
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import site.billilge.api.backend.common.exception.ApiException
+import site.billilge.api.backend.common.exception.GlobalErrorCode
+import site.billilge.api.backend.core.port.FileStorageService
+import site.billilge.api.backend.core.port.FileUploadRequest
+import site.billilge.api.backend.core.vo.PageRequest
+import site.billilge.api.backend.core.vo.PageResult
+import site.billilge.api.backend.domain.item.appender.ItemAppender
+import site.billilge.api.backend.domain.item.entity.Item
+import site.billilge.api.backend.domain.item.enums.ItemType
+import site.billilge.api.backend.domain.item.exception.ItemErrorCode
+import site.billilge.api.backend.domain.item.reader.ItemReader
+import site.billilge.api.backend.domain.item.remover.ItemRemover
+import site.billilge.api.backend.domain.item.repository.dto.ItemWithRentCountQueryResult
+
+private val log = KotlinLogging.logger {}
+
+@Service
+@Transactional(readOnly = true)
+class ItemService(
+    private val itemReader: ItemReader,
+    private val itemAppender: ItemAppender,
+    private val itemRemover: ItemRemover,
+    private val fileStorageService: FileStorageService,
+) {
+    fun getAllItems(): List<Item> = itemReader.readAll()
+
+    fun getAllAdminItems(keyword: String, pageRequest: PageRequest): PageResult<ItemWithRentCountQueryResult> =
+        itemReader.readAllAsAdminDetail(keyword, pageRequest)
+
+    fun searchItems(search: String): List<Item> = itemReader.readByItemName(search)
+
+    fun getItemById(itemId: Long): Item = itemReader.read(itemId)
+
+    @Transactional
+    fun addItem(file: FileUploadRequest, name: String, type: ItemType, count: Int) {
+        if (itemReader.existsByName(name)) throw ApiException(ItemErrorCode.ITEM_NAME_ALREADY_EXISTS)
+        checkFileIsSvg(file)
+
+        val imageUrl = fileStorageService.uploadImageFile(file)
+            ?: throw ApiException(GlobalErrorCode.IMAGE_UPLOAD_FAILED)
+
+        try {
+            itemAppender.save(Item(id = null, name = name, type = type, count = count, imageUrl = imageUrl))
+        } catch (e: Exception) {
+            runCatching { fileStorageService.deleteImageFile(imageUrl) }
+                .onFailure { log.warn { "Failed to delete orphan image after save failure: $imageUrl" } }
+            throw e
+        }
+    }
+
+    @Transactional
+    fun updateItem(file: FileUploadRequest?, itemId: Long, name: String, type: ItemType, count: Int) {
+        val item = itemReader.read(itemId)
+        val oldImageUrl = item.imageUrl
+
+        val newImageUrl = if (file == null) {
+            oldImageUrl
+        } else {
+            checkFileIsSvg(file)
+            fileStorageService.uploadImageFile(file) ?: throw ApiException(GlobalErrorCode.IMAGE_UPLOAD_FAILED)
+        }
+
+        try {
+            itemAppender.save(item.copy(name = name, type = type, count = count, imageUrl = newImageUrl))
+        } catch (e: Exception) {
+            if (newImageUrl != oldImageUrl) {
+                runCatching { fileStorageService.deleteImageFile(newImageUrl) }
+                    .onFailure { log.warn { "Failed to delete orphan image after update failure: $newImageUrl" } }
+            }
+            throw e
+        }
+
+        if (newImageUrl != oldImageUrl) {
+            runCatching { fileStorageService.deleteImageFile(oldImageUrl) }
+                .onFailure { log.warn { "Failed to delete replaced image: $oldImageUrl" } }
+        }
+    }
+
+    @Transactional
+    fun deleteItem(itemId: Long) {
+        val item = itemReader.read(itemId)
+        itemRemover.remove(itemId)
+        fileStorageService.deleteImageFile(item.imageUrl)
+    }
+
+    @Transactional
+    fun adjustCount(itemId: Long, delta: Int) {
+        val item = itemReader.read(itemId)
+        itemAppender.save(item.copy(count = maxOf(0, item.count + delta)))
+    }
+
+    private fun checkFileIsSvg(file: FileUploadRequest) {
+        if (file.contentType != "image/svg+xml") throw ApiException(ItemErrorCode.IMAGE_IS_NOT_SVG)
+    }
+}

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/member/appender/MemberAppender.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/member/appender/MemberAppender.kt
@@ -1,0 +1,14 @@
+package site.billilge.api.backend.domain.member.appender
+
+import org.springframework.stereotype.Component
+import site.billilge.api.backend.domain.member.entity.Member
+import site.billilge.api.backend.domain.member.repository.MemberRepository
+
+@Component
+class MemberAppender(private val memberRepository: MemberRepository) {
+
+    fun save(member: Member): Member = memberRepository.save(member)
+
+    fun saveAll(members: List<Member>): List<Member> =
+        members.map { memberRepository.save(it) }
+}

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/member/reader/MemberReader.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/member/reader/MemberReader.kt
@@ -1,0 +1,46 @@
+package site.billilge.api.backend.domain.member.reader
+
+import org.springframework.stereotype.Component
+import site.billilge.api.backend.common.exception.ApiException
+import site.billilge.api.backend.core.vo.PageRequest
+import site.billilge.api.backend.core.vo.PageResult
+import site.billilge.api.backend.domain.member.entity.Member
+import site.billilge.api.backend.domain.member.enums.Role
+import site.billilge.api.backend.domain.member.exception.MemberErrorCode
+import site.billilge.api.backend.domain.member.repository.MemberRepository
+
+@Component
+class MemberReader(private val memberRepository: MemberRepository) {
+
+    fun read(id: Long): Member =
+        memberRepository.findById(id) ?: throw ApiException(MemberErrorCode.MEMBER_NOT_FOUND)
+
+    fun readOrNull(id: Long): Member? = memberRepository.findById(id)
+
+    fun readByEmail(email: String): Member? = memberRepository.findByEmail(email)
+
+    fun readByStudentId(studentId: String): Member? = memberRepository.findByStudentId(studentId)
+
+    fun readByStudentIdAndName(studentId: String, name: String): Member? =
+        memberRepository.findByStudentIdAndName(studentId, name)
+
+    fun existsByEmail(email: String): Boolean = memberRepository.existsByEmail(email)
+
+    fun existsByStudentIdAndName(studentId: String, name: String): Boolean =
+        memberRepository.existsByStudentIdAndName(studentId, name)
+
+    fun readAllByIds(ids: List<Long>): List<Member> = memberRepository.findAllByIds(ids)
+
+    fun readAllByStudentIds(studentIds: List<String>): List<Member> =
+        memberRepository.findAllByStudentIds(studentIds)
+
+    fun readAllByRole(role: Role): List<Member> = memberRepository.findAllByRole(role)
+
+    fun readAllByRoleIn(roles: Set<Role>): List<Member> = memberRepository.findAllByRoleIn(roles)
+
+    fun readAllByRoleInAndNameContaining(roles: List<Role>, name: String, pageRequest: PageRequest): PageResult<Member> =
+        memberRepository.findAllByRoleInAndNameContaining(roles, name, pageRequest)
+
+    fun readAllByNameContaining(name: String, pageRequest: PageRequest): PageResult<Member> =
+        memberRepository.findAllByNameContaining(name, pageRequest)
+}

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/member/service/MemberService.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/member/service/MemberService.kt
@@ -1,0 +1,95 @@
+package site.billilge.api.backend.domain.member.service
+
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import site.billilge.api.backend.common.exception.ApiException
+import site.billilge.api.backend.core.vo.PageRequest
+import site.billilge.api.backend.core.vo.PageResult
+import site.billilge.api.backend.domain.configvalue.enums.ConfigValueKeys
+import site.billilge.api.backend.domain.configvalue.service.ConfigValueService
+import site.billilge.api.backend.domain.member.appender.MemberAppender
+import site.billilge.api.backend.domain.member.entity.Member
+import site.billilge.api.backend.domain.member.enums.Role
+import site.billilge.api.backend.domain.member.exception.MemberErrorCode
+import site.billilge.api.backend.domain.member.reader.MemberReader
+import site.billilge.api.backend.domain.payer.service.PayerService
+
+@Service
+@Transactional(readOnly = true)
+class MemberService(
+    private val memberReader: MemberReader,
+    private val memberAppender: MemberAppender,
+    private val payerService: PayerService,
+    private val configValueService: ConfigValueService,
+) {
+    @Transactional
+    fun signUp(email: String, studentId: String, name: String): Member {
+        if (memberReader.existsByEmail(email)) throw ApiException(MemberErrorCode.EMAIL_ALREADY_EXISTS)
+
+        if (memberReader.existsByStudentIdAndName(studentId, name)) {
+            val existing = memberReader.readByStudentId(studentId)!!
+            return memberAppender.save(existing.copy(email = email))
+        }
+
+        val isFeePaid = payerService.isPayer(name, studentId)
+        val newMember = Member(id = null, name = name, studentId = studentId, isFeePaid = isFeePaid, email = email)
+        val saved = memberAppender.save(newMember)
+        payerService.updatePayerInfo(saved)
+        return saved
+    }
+
+    fun loginAdmin(studentId: String, password: String): Member {
+        val member = memberReader.readByStudentId(studentId)
+            ?: throw ApiException(MemberErrorCode.MEMBER_NOT_FOUND)
+
+        if (password != configValueService.getValueByKey(ConfigValueKeys.ADMIN_PASSWORD.key))
+            throw ApiException(MemberErrorCode.ADMIN_PASSWORD_MISMATCH)
+
+        if (member.role !in listOf(Role.ADMIN, Role.GA, Role.WORKER))
+            throw ApiException(MemberErrorCode.FORBIDDEN)
+
+        return member
+    }
+
+    fun findById(memberId: Long): Member = memberReader.read(memberId)
+
+    fun findAllWorkers(): List<Member> = memberReader.readAllByRoleIn(setOf(Role.WORKER, Role.ADMIN, Role.GA))
+
+    fun getAdminList(pageRequest: PageRequest, search: String): PageResult<Member> =
+        memberReader.readAllByRoleInAndNameContaining(listOf(Role.ADMIN, Role.WORKER, Role.GA), search, pageRequest)
+
+    fun getAllMembers(pageRequest: PageRequest, search: String): PageResult<Member> =
+        memberReader.readAllByNameContaining(search, pageRequest)
+
+    @Transactional
+    fun updateAdminRole(memberId: Long, role: Role) {
+        val member = memberReader.read(memberId)
+        memberAppender.save(member.copy(role = role))
+    }
+
+    @Transactional
+    fun addAdmins(memberIds: List<Long>, role: Role) {
+        memberReader.readAllByIds(memberIds)
+            .map { it.copy(role = role) }
+            .let { memberAppender.saveAll(it) }
+    }
+
+    @Transactional
+    fun deleteAdmins(memberIds: List<Long>) {
+        memberReader.readAllByIds(memberIds)
+            .map { it.copy(role = Role.USER) }
+            .let { memberAppender.saveAll(it) }
+    }
+
+    @Transactional
+    fun setMemberFCMToken(memberId: Long, token: String) {
+        val member = memberReader.read(memberId)
+        memberAppender.save(member.copy(fcmToken = token))
+    }
+
+    @Transactional
+    fun clearFcmToken(memberId: Long) {
+        val member = memberReader.readOrNull(memberId) ?: return
+        memberAppender.save(member.copy(fcmToken = null))
+    }
+}

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/notification/appender/NotificationAppender.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/notification/appender/NotificationAppender.kt
@@ -1,0 +1,14 @@
+package site.billilge.api.backend.domain.notification.appender
+
+import org.springframework.stereotype.Component
+import site.billilge.api.backend.domain.notification.entity.Notification
+import site.billilge.api.backend.domain.notification.repository.NotificationRepository
+
+@Component
+class NotificationAppender(private val notificationRepository: NotificationRepository) {
+
+    fun save(notification: Notification): Notification = notificationRepository.save(notification)
+
+    fun saveAll(notifications: List<Notification>): List<Notification> =
+        notificationRepository.saveAll(notifications)
+}

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/notification/reader/NotificationReader.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/notification/reader/NotificationReader.kt
@@ -1,0 +1,23 @@
+package site.billilge.api.backend.domain.notification.reader
+
+import org.springframework.stereotype.Component
+import site.billilge.api.backend.common.exception.ApiException
+import site.billilge.api.backend.domain.notification.entity.Notification
+import site.billilge.api.backend.domain.notification.exception.NotificationErrorCode
+import site.billilge.api.backend.domain.notification.repository.NotificationRepository
+
+@Component
+class NotificationReader(private val notificationRepository: NotificationRepository) {
+
+    fun read(id: Long): Notification =
+        notificationRepository.findById(id) ?: throw ApiException(NotificationErrorCode.NOTIFICATION_NOT_FOUND)
+
+    fun readAllUserByMemberId(memberId: Long): List<Notification> =
+        notificationRepository.findAllUserNotificationsByMemberId(memberId)
+
+    fun readAllAdminByMemberId(memberId: Long): List<Notification> =
+        notificationRepository.findAllAdminNotificationsByMemberId(memberId)
+
+    fun countUnreadByMemberId(memberId: Long): Int =
+        notificationRepository.countUserNotificationsByMemberId(memberId)
+}

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/notification/service/NotificationService.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/notification/service/NotificationService.kt
@@ -1,0 +1,82 @@
+package site.billilge.api.backend.domain.notification.service
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import site.billilge.api.backend.common.exception.ApiException
+import site.billilge.api.backend.core.port.FCMPort
+import site.billilge.api.backend.domain.member.entity.Member
+import site.billilge.api.backend.domain.member.service.MemberService
+import site.billilge.api.backend.domain.notification.appender.NotificationAppender
+import site.billilge.api.backend.domain.notification.entity.Notification
+import site.billilge.api.backend.domain.notification.enums.NotificationStatus
+import site.billilge.api.backend.domain.notification.exception.NotificationErrorCode
+import site.billilge.api.backend.domain.notification.reader.NotificationReader
+
+private val log = KotlinLogging.logger {}
+
+@Service
+@Transactional(readOnly = true)
+class NotificationService(
+    private val notificationReader: NotificationReader,
+    private val notificationAppender: NotificationAppender,
+    private val fcmPort: FCMPort,
+    private val memberService: MemberService,
+) {
+    fun getNotifications(memberId: Long): List<Notification> =
+        notificationReader.readAllUserByMemberId(memberId)
+
+    fun getAdminNotifications(memberId: Long): List<Notification> =
+        notificationReader.readAllAdminByMemberId(memberId)
+
+    fun getNotificationCount(memberId: Long): Int =
+        notificationReader.countUnreadByMemberId(memberId)
+
+    @Transactional
+    fun readNotification(memberId: Long, notificationId: Long) {
+        val notification = notificationReader.read(notificationId)
+        if (notification.status.name.contains("ADMIN", ignoreCase = true)) return
+        if (notification.member?.id != memberId) throw ApiException(NotificationErrorCode.NOTIFICATION_ACCESS_DENIED)
+        notificationAppender.save(notification.copy(isRead = true))
+    }
+
+    @Transactional
+    fun readAllNotifications(memberId: Long) {
+        val notifications = notificationReader.readAllUserByMemberId(memberId)
+        notificationAppender.saveAll(notifications.filter { !it.isRead }.map { it.copy(isRead = true) })
+    }
+
+    @Transactional
+    fun sendNotification(member: Member, status: NotificationStatus, formatValues: List<String>, needPush: Boolean = false) {
+        notificationAppender.save(
+            Notification(id = null, member = member, status = status, formatValues = formatValues.joinToString(","))
+        )
+        if (needPush) sendPushNotification(member, status, formatValues)
+    }
+
+    @Transactional
+    fun sendNotificationToAdmin(status: NotificationStatus, formatValues: List<String>, needPush: Boolean = false) {
+        notificationAppender.save(
+            Notification(id = null, member = null, status = status, formatValues = formatValues.joinToString(","))
+        )
+        if (needPush) {
+            memberService.findAllWorkers().forEach { sendPushNotification(it, status, formatValues) }
+        }
+    }
+
+    private fun sendPushNotification(member: Member, status: NotificationStatus, formatValues: List<String>) {
+        val fcmToken = member.fcmToken
+        if (fcmToken == null) {
+            log.warn { "(studentId=${member.studentId}) FCM Token is null" }
+            return
+        }
+        val isTokenValid = fcmPort.sendPushNotification(
+            fcmToken = fcmToken,
+            title = status.title,
+            body = status.formattedMessage(*formatValues.toTypedArray()),
+            link = status.link,
+            studentId = member.studentId,
+        )
+        if (!isTokenValid) memberService.clearFcmToken(member.id!!)
+    }
+}

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/payer/appender/PayerAppender.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/payer/appender/PayerAppender.kt
@@ -1,0 +1,13 @@
+package site.billilge.api.backend.domain.payer.appender
+
+import org.springframework.stereotype.Component
+import site.billilge.api.backend.domain.payer.entity.Payer
+import site.billilge.api.backend.domain.payer.repository.PayerRepository
+
+@Component
+class PayerAppender(private val payerRepository: PayerRepository) {
+
+    fun save(payer: Payer): Payer = payerRepository.save(payer)
+
+    fun saveAll(payers: List<Payer>): List<Payer> = payerRepository.saveAll(payers)
+}

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/payer/reader/PayerReader.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/payer/reader/PayerReader.kt
@@ -1,0 +1,24 @@
+package site.billilge.api.backend.domain.payer.reader
+
+import org.springframework.stereotype.Component
+import site.billilge.api.backend.core.vo.PageRequest
+import site.billilge.api.backend.core.vo.PageResult
+import site.billilge.api.backend.domain.payer.entity.Payer
+import site.billilge.api.backend.domain.payer.repository.PayerRepository
+
+@Component
+class PayerReader(private val payerRepository: PayerRepository) {
+
+    fun readAllByNameAndEnrollmentYear(name: String, enrollmentYear: String): List<Payer> =
+        payerRepository.findAllByNameAndEnrollmentYear(name, enrollmentYear)
+
+    fun readAllByIds(ids: List<Long>): List<Payer> = payerRepository.findAllByIds(ids)
+
+    fun readAllByNameContaining(name: String, pageRequest: PageRequest): PageResult<Payer> =
+        payerRepository.findAllByNameContaining(name, pageRequest)
+
+    fun readAllByEnrollmentYear(enrollmentYear: String): List<Payer> =
+        payerRepository.findAllByEnrollmentYear(enrollmentYear)
+
+    fun readAll(): List<Payer> = payerRepository.findAll()
+}

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/payer/remover/PayerRemover.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/payer/remover/PayerRemover.kt
@@ -1,0 +1,10 @@
+package site.billilge.api.backend.domain.payer.remover
+
+import org.springframework.stereotype.Component
+import site.billilge.api.backend.domain.payer.repository.PayerRepository
+
+@Component
+class PayerRemover(private val payerRepository: PayerRepository) {
+
+    fun removeAll(ids: List<Long>) = payerRepository.deleteAll(ids)
+}

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/payer/service/PayerService.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/payer/service/PayerService.kt
@@ -1,0 +1,94 @@
+package site.billilge.api.backend.domain.payer.service
+
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import site.billilge.api.backend.common.utils.ExcelRow
+import site.billilge.api.backend.core.port.ExcelGeneratorPort
+import site.billilge.api.backend.core.vo.PageRequest
+import site.billilge.api.backend.core.vo.PageResult
+import site.billilge.api.backend.domain.member.appender.MemberAppender
+import site.billilge.api.backend.domain.member.entity.Member
+import site.billilge.api.backend.domain.member.reader.MemberReader
+import site.billilge.api.backend.domain.payer.appender.PayerAppender
+import site.billilge.api.backend.domain.payer.entity.Payer
+import site.billilge.api.backend.domain.payer.reader.PayerReader
+import site.billilge.api.backend.domain.payer.remover.PayerRemover
+import java.io.ByteArrayInputStream
+import java.time.Year
+
+@Service
+@Transactional(readOnly = true)
+class PayerService(
+    private val payerReader: PayerReader,
+    private val payerAppender: PayerAppender,
+    private val payerRemover: PayerRemover,
+    private val memberReader: MemberReader,
+    private val memberAppender: MemberAppender,
+    private val excelGeneratorPort: ExcelGeneratorPort,
+) {
+    fun isPayer(name: String, studentId: String): Boolean {
+        val enrollmentYear = studentId.substring(0, 4)
+        val payers = payerReader.readAllByNameAndEnrollmentYear(name, enrollmentYear)
+        if (payers.isEmpty()) return false
+        if (payers.size == 1 && studentId.substring(4, 8) == "XXXX") return true
+        return payers.any { it.studentId == studentId }
+    }
+
+    @Transactional
+    fun updatePayerInfo(member: Member) {
+        val payers = payerReader.readAllByNameAndEnrollmentYear(member.name, member.studentId.substring(0, 4))
+        if (payers.isEmpty()) return
+
+        val target = if (payers.size > 1) payers.first { it.studentId == member.studentId } else payers[0]
+        payerAppender.save(target.copy(registered = true, studentId = member.studentId))
+    }
+
+    fun getAllPayers(pageRequest: PageRequest, search: String): PageResult<Payer> =
+        payerReader.readAllByNameContaining(search, pageRequest)
+
+    @Transactional
+    fun addPayers(payers: List<Pair<String, String>>) {
+        val newPayers = mutableListOf<Payer>()
+
+        payers.forEach { (name, studentId) ->
+            val enrollmentYear = studentId.substring(0, 4)
+            val registeredMember = memberReader.readByStudentIdAndName(studentId, name)
+
+            if (!isPayer(name, studentId)) {
+                newPayers.add(
+                    Payer(id = null, name = name, enrollmentYear = enrollmentYear,
+                        studentId = studentId, registered = registeredMember != null)
+                )
+            }
+
+            registeredMember?.let { memberAppender.save(it.copy(isFeePaid = true)) }
+        }
+
+        payerAppender.saveAll(newPayers)
+    }
+
+    @Transactional
+    fun deletePayers(payerIds: List<Long>) {
+        val studentIds = payerReader.readAllByIds(payerIds).mapNotNull { it.studentId }
+        memberReader.readAllByStudentIds(studentIds)
+            .map { it.copy(isFeePaid = false) }
+            .let { memberAppender.saveAll(it) }
+        payerRemover.removeAll(payerIds)
+    }
+
+    fun createPayerExcel(): ByteArrayInputStream {
+        val startYear = 2015
+        val currentYear = Year.now().value
+        val headerTitles = arrayOf("이름", "학번")
+        val sheetData = mutableMapOf<String, Pair<Array<String>, List<ExcelRow>>>()
+
+        for (year in currentYear downTo startYear) {
+            val yearText = "$year"
+            val rows = payerReader.readAllByEnrollmentYear(yearText)
+                .map { ExcelRow(it.name, it.studentId ?: "${yearText}XXXX") }
+            sheetData[yearText] = headerTitles to rows
+        }
+
+        return excelGeneratorPort.generateByMultipleSheets(sheetData)
+    }
+}

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/rental/appender/RentalAppender.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/rental/appender/RentalAppender.kt
@@ -1,0 +1,11 @@
+package site.billilge.api.backend.domain.rental.appender
+
+import org.springframework.stereotype.Component
+import site.billilge.api.backend.domain.rental.entity.RentalHistory
+import site.billilge.api.backend.domain.rental.repository.RentalRepository
+
+@Component
+class RentalAppender(private val rentalRepository: RentalRepository) {
+
+    fun save(rentalHistory: RentalHistory): RentalHistory = rentalRepository.save(rentalHistory)
+}

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/rental/appender/RentalStatusWorkerLogAppender.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/rental/appender/RentalStatusWorkerLogAppender.kt
@@ -1,0 +1,12 @@
+package site.billilge.api.backend.domain.rental.appender
+
+import org.springframework.stereotype.Component
+import site.billilge.api.backend.domain.rental.entity.RentalStatusWorkerLog
+import site.billilge.api.backend.domain.rental.repository.RentalStatusWorkerLogRepository
+
+@Component
+class RentalStatusWorkerLogAppender(private val rentalStatusWorkerLogRepository: RentalStatusWorkerLogRepository) {
+
+    fun save(log: RentalStatusWorkerLog): RentalStatusWorkerLog =
+        rentalStatusWorkerLogRepository.save(log)
+}

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/rental/reader/RentalReader.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/rental/reader/RentalReader.kt
@@ -1,0 +1,35 @@
+package site.billilge.api.backend.domain.rental.reader
+
+import org.springframework.stereotype.Component
+import site.billilge.api.backend.common.exception.ApiException
+import site.billilge.api.backend.core.vo.PageRequest
+import site.billilge.api.backend.core.vo.PageResult
+import site.billilge.api.backend.domain.rental.entity.RentalHistory
+import site.billilge.api.backend.domain.rental.enums.RentalStatus
+import site.billilge.api.backend.domain.rental.exception.RentalErrorCode
+import site.billilge.api.backend.domain.rental.repository.RentalRepository
+
+@Component
+class RentalReader(private val rentalRepository: RentalRepository) {
+
+    fun read(id: Long): RentalHistory =
+        rentalRepository.findById(id) ?: throw ApiException(RentalErrorCode.RENTAL_NOT_FOUND)
+
+    fun readByMemberId(memberId: Long): List<RentalHistory> =
+        rentalRepository.findByMemberId(memberId)
+
+    fun readByItemIdAndMemberIdAndStatus(itemId: Long, memberId: Long, status: RentalStatus): RentalHistory? =
+        rentalRepository.findByItemIdAndMemberIdAndRentalStatus(itemId, memberId, status)
+
+    fun readByMemberIdAndStatus(memberId: Long, status: RentalStatus): List<RentalHistory> =
+        rentalRepository.findByMemberIdAndRentalStatus(memberId, status)
+
+    fun readByMemberIdAndStatusIn(memberId: Long, statuses: Collection<RentalStatus>): List<RentalHistory> =
+        rentalRepository.findByMemberIdAndRentalStatusIn(memberId, statuses)
+
+    fun readAllByStatusIn(statuses: List<RentalStatus>): List<RentalHistory> =
+        rentalRepository.findAllByRentalStatusIn(statuses)
+
+    fun readAllByMemberNameContaining(memberName: String, pageRequest: PageRequest): PageResult<RentalHistory> =
+        rentalRepository.findAllByMemberNameContaining(memberName, pageRequest)
+}

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/rental/reader/RentalStatusWorkerLogReader.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/rental/reader/RentalStatusWorkerLogReader.kt
@@ -1,0 +1,12 @@
+package site.billilge.api.backend.domain.rental.reader
+
+import org.springframework.stereotype.Component
+import site.billilge.api.backend.domain.rental.entity.RentalStatusWorkerLog
+import site.billilge.api.backend.domain.rental.repository.RentalStatusWorkerLogRepository
+
+@Component
+class RentalStatusWorkerLogReader(private val rentalStatusWorkerLogRepository: RentalStatusWorkerLogRepository) {
+
+    fun readAllByRentalHistoryId(rentalHistoryId: Long): List<RentalStatusWorkerLog> =
+        rentalStatusWorkerLogRepository.findAllByRentalHistoryIdOrderByCreatedAtAsc(rentalHistoryId)
+}

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/rental/remover/RentalRemover.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/rental/remover/RentalRemover.kt
@@ -1,0 +1,10 @@
+package site.billilge.api.backend.domain.rental.remover
+
+import org.springframework.stereotype.Component
+import site.billilge.api.backend.domain.rental.repository.RentalRepository
+
+@Component
+class RentalRemover(private val rentalRepository: RentalRepository) {
+
+    fun remove(id: Long) = rentalRepository.delete(id)
+}

--- a/core/src/main/kotlin/site/billilge/api/backend/domain/rental/service/RentalService.kt
+++ b/core/src/main/kotlin/site/billilge/api/backend/domain/rental/service/RentalService.kt
@@ -1,0 +1,197 @@
+package site.billilge.api.backend.domain.rental.service
+
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import site.billilge.api.backend.common.exception.ApiException
+import site.billilge.api.backend.common.utils.isWeekend
+import site.billilge.api.backend.core.vo.PageRequest
+import site.billilge.api.backend.core.vo.PageResult
+import site.billilge.api.backend.domain.configvalue.enums.ConfigValueKeys
+import site.billilge.api.backend.domain.configvalue.service.ConfigValueService
+import site.billilge.api.backend.domain.item.entity.Item
+import site.billilge.api.backend.domain.item.enums.ItemType
+import site.billilge.api.backend.domain.item.service.ItemService
+import site.billilge.api.backend.domain.member.entity.Member
+import site.billilge.api.backend.domain.member.enums.Role
+import site.billilge.api.backend.domain.member.exception.MemberErrorCode
+import site.billilge.api.backend.domain.rental.appender.RentalAppender
+import site.billilge.api.backend.domain.rental.appender.RentalStatusWorkerLogAppender
+import site.billilge.api.backend.domain.rental.entity.RentalHistory
+import site.billilge.api.backend.domain.rental.entity.RentalStatusWorkerLog
+import site.billilge.api.backend.domain.rental.enums.RentalStatus
+import site.billilge.api.backend.domain.rental.event.RentalAppliedEvent
+import site.billilge.api.backend.domain.rental.event.RentalCancelledEvent
+import site.billilge.api.backend.domain.rental.event.RentalStatusChangedEvent
+import site.billilge.api.backend.domain.rental.event.ReturnAppliedEvent
+import site.billilge.api.backend.domain.rental.exception.RentalErrorCode
+import site.billilge.api.backend.domain.rental.reader.RentalReader
+import site.billilge.api.backend.domain.rental.reader.RentalStatusWorkerLogReader
+import site.billilge.api.backend.domain.rental.remover.RentalRemover
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+@Service
+@Transactional(readOnly = true)
+class RentalService(
+    private val rentalReader: RentalReader,
+    private val rentalAppender: RentalAppender,
+    private val rentalRemover: RentalRemover,
+    private val rentalStatusWorkerLogAppender: RentalStatusWorkerLogAppender,
+    private val rentalStatusWorkerLogReader: RentalStatusWorkerLogReader,
+    private val eventPublisher: ApplicationEventPublisher,
+    private val configValueService: ConfigValueService,
+    private val itemService: ItemService,
+) {
+    @Transactional
+    fun createRental(rentUser: Member, item: Item, count: Int, rentAt: LocalDateTime, ignoreDuplicate: Boolean, isDevMode: Boolean = false) {
+        validatePayer(rentUser)
+        validateStock(count, item.count)
+
+        if (!ignoreDuplicate) checkDuplicateRental(item.id!!, rentUser.id!!)
+
+        if (isDevMode && rentUser.role != Role.ADMIN) throw ApiException(MemberErrorCode.FORBIDDEN)
+        if (!isDevMode) validateRentalTime(rentAt)
+
+        rentalAppender.save(
+            RentalHistory(id = null, member = rentUser, item = item, rentalStatus = RentalStatus.PENDING,
+                rentedCount = count, rentAt = rentAt)
+        )
+        eventPublisher.publishEvent(RentalAppliedEvent(rentUser.id!!, item.name, rentAt, isDevMode))
+    }
+
+    @Transactional
+    fun createRentalByAdmin(worker: Member, rentUser: Member, item: Item, count: Int, rentAt: LocalDateTime): RentalHistory {
+        validateStock(count, item.count)
+        if (!rentUser.isFeePaid) throw ApiException(RentalErrorCode.MEMBER_IS_NOT_PAYER_ADMIN)
+
+        val status = if (item.type == ItemType.RENTAL) RentalStatus.RENTAL else RentalStatus.RETURNED
+        val returnedAt = if (status == RentalStatus.RETURNED) LocalDateTime.now() else null
+
+        val saved = rentalAppender.save(
+            RentalHistory(id = null, member = rentUser, item = item, rentalStatus = status,
+                rentedCount = count, rentAt = rentAt, returnedAt = returnedAt)
+        )
+        itemService.adjustCount(item.id!!, -count)
+        rentalStatusWorkerLogAppender.save(
+            RentalStatusWorkerLog(id = null, rentalHistoryId = saved.id!!, rentalStatus = status, worker = worker)
+        )
+        return saved
+    }
+
+    @Transactional
+    fun updateRentalStatus(worker: Member, rentalHistoryId: Long, rentalStatus: RentalStatus) {
+        val rentalHistory = rentalReader.read(rentalHistoryId)
+        val item = rentalHistory.item
+
+        if (rentalStatus == RentalStatus.CONFIRMED && item.count <= 0)
+            throw ApiException(RentalErrorCode.ITEM_OUT_OF_STOCK)
+
+        val newStatus = if (rentalStatus == RentalStatus.RENTAL && item.type == ItemType.CONSUMPTION)
+            RentalStatus.RETURNED else rentalStatus
+
+        val returnedAt = if (newStatus == RentalStatus.RETURNED) LocalDateTime.now() else rentalHistory.returnedAt
+        val updatedWorker = if (newStatus == RentalStatus.CONFIRMED) worker else rentalHistory.worker
+
+        when (newStatus) {
+            RentalStatus.CONFIRMED -> {
+                if (rentalHistory.rentedCount > item.count) throw ApiException(RentalErrorCode.ITEM_OUT_OF_STOCK)
+                itemService.adjustCount(item.id!!, -rentalHistory.rentedCount)
+            }
+            RentalStatus.RETURNED -> {
+                if (item.type != ItemType.CONSUMPTION) itemService.adjustCount(item.id!!, +rentalHistory.rentedCount)
+                else return
+            }
+            RentalStatus.REJECTED, RentalStatus.RETURN_CONFIRMED -> Unit
+            else -> return
+        }
+
+        rentalAppender.save(rentalHistory.copy(rentalStatus = newStatus, returnedAt = returnedAt, worker = updatedWorker))
+        eventPublisher.publishEvent(RentalStatusChangedEvent(rentalHistory.member.id!!, item.name, newStatus))
+        rentalStatusWorkerLogAppender.save(
+            RentalStatusWorkerLog(id = null, rentalHistoryId = rentalHistoryId, rentalStatus = newStatus, worker = worker)
+        )
+    }
+
+    @Transactional
+    fun cancelRental(memberId: Long, rentalHistoryId: Long) {
+        val rentalHistory = rentalReader.read(rentalHistoryId)
+        rentalAppender.save(rentalHistory.copy(rentalStatus = RentalStatus.CANCEL))
+        eventPublisher.publishEvent(RentalCancelledEvent(rentalHistory.member.id!!, rentalHistory.item.name))
+    }
+
+    @Transactional
+    fun returnRental(memberId: Long, rentalHistoryId: Long) {
+        val rentalHistory = rentalReader.read(rentalHistoryId)
+        rentalAppender.save(rentalHistory.copy(rentalStatus = RentalStatus.RETURN_PENDING))
+        eventPublisher.publishEvent(ReturnAppliedEvent(rentalHistory.member.id!!, rentalHistory.item.name))
+    }
+
+    @Transactional
+    fun updateItemCode(rentalHistoryId: Long, itemCode: String) {
+        val rentalHistory = rentalReader.read(rentalHistoryId)
+        rentalAppender.save(rentalHistory.copy(itemCode = itemCode))
+    }
+
+    @Transactional
+    fun deleteRentalHistory(rentalHistoryId: Long) = rentalRemover.remove(rentalHistoryId)
+
+    fun getMemberRentalHistory(memberId: Long, rentalStatus: RentalStatus?): List<RentalHistory> =
+        if (rentalStatus == null) rentalReader.readByMemberId(memberId)
+        else rentalReader.readByMemberIdAndStatus(memberId, rentalStatus)
+
+    fun getReturnRequiredItems(memberId: Long): List<RentalHistory> =
+        rentalReader.readByMemberIdAndStatusIn(memberId, RETURN_REQUIRED_STATUS)
+
+    fun getAllDashboardApplications(rentalStatus: RentalStatus?): List<RentalHistory> =
+        rentalReader.readAllByStatusIn(DASHBOARD_STATUS)
+            .filter { if (rentalStatus == null) true else it.rentalStatus == rentalStatus }
+
+    fun getAllRentalHistories(pageRequest: PageRequest, search: String): PageResult<RentalHistory> =
+        rentalReader.readAllByMemberNameContaining(search, pageRequest)
+
+    fun getWorkerLogs(rentalHistoryId: Long) =
+        rentalStatusWorkerLogReader.readAllByRentalHistoryId(rentalHistoryId)
+
+    private fun validatePayer(member: Member) {
+        if (!member.isFeePaid) throw ApiException(RentalErrorCode.MEMBER_IS_NOT_PAYER)
+    }
+
+    private fun validateStock(rentedCount: Int, availableCount: Int) {
+        if (rentedCount > availableCount) throw ApiException(RentalErrorCode.ITEM_OUT_OF_STOCK)
+    }
+
+    private fun checkDuplicateRental(itemId: Long, memberId: Long) {
+        if (rentalReader.readByItemIdAndMemberIdAndStatus(itemId, memberId, RentalStatus.RENTAL) != null)
+            throw ApiException(RentalErrorCode.RENTAL_ITEM_DUPLICATED)
+    }
+
+    private fun validateRentalTime(rentAt: LocalDateTime) {
+        if (rentAt.toLocalDate().isInExamPeriod) throw ApiException(RentalErrorCode.TODAY_IS_IN_EXAM_PERIOD)
+        if (rentAt.isWeekend) throw ApiException(RentalErrorCode.INVALID_RENTAL_TIME_WEEKEND)
+        if (rentAt.isBefore(LocalDateTime.now(ZoneId.of("Asia/Seoul"))))
+            throw ApiException(RentalErrorCode.INVALID_RENTAL_TIME_PAST)
+        if (rentAt.hour < 10 || rentAt.hour > 17)
+            throw ApiException(RentalErrorCode.INVALID_RENTAL_TIME_OUT_OF_RANGE)
+    }
+
+    private val LocalDate.isInExamPeriod: Boolean
+        get() {
+            val config = configValueService.getMapByKeys(
+                listOf(ConfigValueKeys.EXAM_PERIOD_START_DATE.key, ConfigValueKeys.EXAM_PERIOD_END_DATE.key)
+            )
+            val start = LocalDate.parse(config[ConfigValueKeys.EXAM_PERIOD_START_DATE.key] ?: return false)
+            val end = LocalDate.parse(config[ConfigValueKeys.EXAM_PERIOD_END_DATE.key] ?: return false)
+            return this in (start..end)
+        }
+
+    companion object {
+        private val DASHBOARD_STATUS = listOf(
+            RentalStatus.PENDING, RentalStatus.RETURN_PENDING,
+            RentalStatus.RETURN_CONFIRMED, RentalStatus.CONFIRMED,
+        )
+        private val RETURN_REQUIRED_STATUS =
+            listOf(RentalStatus.RENTAL, RentalStatus.RETURN_PENDING, RentalStatus.RETURN_CONFIRMED)
+    }
+}


### PR DESCRIPTION
## 개요

Phase 4: core 모듈에 Reader/Appender/Remover 패턴과 Service 레이어를 구성합니다.

## 변경 사항

### Reader / Appender / Remover 패턴

Service가 Repository를 직접 참조하지 않고 단일 책임 컴포넌트를 통해 접근합니다.

| 클래스 | 역할 |
|--------|------|
| `{Domain}Reader` | Repository 조회 위임. 필수 조회 시 not-found 예외 처리 |
| `{Domain}Appender` | Repository 저장 위임 |
| `{Domain}Remover` | Repository 삭제 위임 |

7개 도메인 전체 적용: item, member, notification, payer, rental, configvalue, display

### Service 재작성

- **ItemService**: `MultipartFile` → `FileUploadRequest`, `adjustCount()` 추가 (RentalService가 호출)
- **MemberService**: `TokenProvider` 의존성 제거 — `signUp()` / `loginAdmin()`이 `Member` 반환 (토큰 생성은 api Facade 책임)
- **NotificationService**: `FCMService` → `FCMPort` (Port 인터페이스로 역전)
- **PayerService**: `ExcelGenerator` → `ExcelGeneratorPort`, `MemberRepository` 대신 `MemberReader`/`MemberAppender` 직접 사용 (순환 의존 방지)
- **RentalService**: 상태 변경 시 엔티티 뮤테이션 → 순수 data class `copy()` 사용, `ItemService.adjustCount()` 호출로 크로스 도메인 접근

### 페이지네이션

모든 Service의 `Page<T>` / `Pageable` → `PageResult<T>` / `PageRequest` (core 자체 VO)

### Gradle

- `core/build.gradle.kts`: `spring-tx`(Transactional 어노테이션), `kotlin-logging-jvm` 추가

## 검증

```
./gradlew :core:compileKotlin  ✅
```

## 관련 이슈

Phase 4 of #126