### PR TITLE
fix: 납부자 목록 조회 정렬 순서와 불일치하는 인덱스 수정

### DIFF
--- a/src/main/kotlin/site/billilge/api/backend/domain/payer/entity/Payer.kt
+++ b/src/main/kotlin/site/billilge/api/backend/domain/payer/entity/Payer.kt
@@ -5,7 +5,7 @@ import jakarta.persistence.*
 @Entity
 @Table(
     name = "payer",
-    indexes = [Index(name = "idx_payer_name_enrollment_year", columnList = "name, enrollment_year")]
+    indexes = [Index(name = "idx_payer_enrollment_year_name", columnList = "enrollment_year DESC, name")]
 )
 class Payer(
     @Column(nullable = false)


### PR DESCRIPTION
## #️⃣연관된 이슈

- #142

## 📝작업 내용

납부자 목록 조회 쿼리의 정렬 순서와 일치하지 않던 `Payer` 인덱스를 수정합니다.

### 원인

기존 인덱스는 `(name, enrollment_year)` 순서로 정의되어 있었습니다. 하지만 실제 납부자 목록 조회는 `ORDER BY enrollment_year DESC, name` 으로 정렬합니다.

복합 인덱스는 선두 컬럼부터 순서대로 정렬되어 있어야 `ORDER BY` 에 활용될 수 있는데, 기존 인덱스는 선두 컬럼이 `name` 이라 정렬에 사용되지 못하고 매 조회마다 filesort가 발생했습니다.

### 수정 내용

인덱스 컬럼 순서를 실제 조회 쿼리의 정렬 순서와 동일하게 맞췄습니다.

| 구분 | 변경 전 | 변경 후 |
|------|---------|---------|
| 인덱스명 | `idx_payer_name_enrollment_year` | `idx_payer_enrollment_year_name` |
| 컬럼 순서 | `name, enrollment_year` | `enrollment_year DESC, name` |

`enrollment_year` 를 선두 컬럼으로 두고 조회 쿼리와 동일하게 `DESC` 를 명시해, 정렬을 위한 별도 filesort 없이 인덱스 순서를 그대로 활용할 수 있습니다.

`findAllByNameAndEnrollmentYear()` 처럼 두 컬럼을 모두 등치 조건으로 사용하는 쿼리는 컬럼 순서가 바뀌어도 동일하게 인덱스를 사용하므로 영향이 없습니다.

`columnList` 에는 엔티티 필드명(`enrollmentYear`)이 아닌 실제 DB 컬럼명(`enrollment_year`)을 사용해야 하므로 이에 맞춰 작성했습니다.

## 💬리뷰 요구사항(선택)

`ddl-auto: update` 환경에서는 기존 인덱스(`idx_payer_name_enrollment_year`)가 자동으로 제거되지 않고 남아있게 됩니다. 배포 후 수동으로 drop이 필요할지 확인 부탁드립니다.
